### PR TITLE
feat(net): optimize transaction rate limiting with accurate cache siz…

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -468,6 +468,9 @@ public class CommonParameter {
   public long pendingTransactionTimeout;
   @Getter
   @Setter
+  public int maxTrxCacheSize; // clearParam: 50000
+  @Getter
+  @Setter
   public boolean nodeMetricsEnable = false;
   @Getter
   @Setter

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -634,6 +634,9 @@ public class Args extends CommonParameter {
     PARAMETER.pendingTransactionTimeout = config.hasPath(ConfigKey.NODE_PENDING_TRANSACTION_TIMEOUT)
         ? config.getLong(ConfigKey.NODE_PENDING_TRANSACTION_TIMEOUT) : 60_000;
 
+    PARAMETER.maxTrxCacheSize = config.hasPath(ConfigKey.NODE_MAX_TRX_CACHE_SIZE)
+        ? config.getInt(ConfigKey.NODE_MAX_TRX_CACHE_SIZE) : 50_000;
+
     PARAMETER.needToUpdateAsset =
         !config.hasPath(ConfigKey.STORAGE_NEEDTO_UPDATE_ASSET) || config
             .getBoolean(ConfigKey.STORAGE_NEEDTO_UPDATE_ASSET);

--- a/framework/src/main/java/org/tron/core/config/args/ConfigKey.java
+++ b/framework/src/main/java/org/tron/core/config/args/ConfigKey.java
@@ -84,6 +84,7 @@ final class ConfigKey {
   public static final String NODE_PRODUCED_TIMEOUT = "node.blockProducedTimeOut";
   public static final String NODE_MAX_TRANSACTION_PENDING_SIZE = "node.maxTransactionPendingSize";
   public static final String NODE_PENDING_TRANSACTION_TIMEOUT = "node.pendingTransactionTimeout";
+  public static final String NODE_MAX_TRX_CACHE_SIZE = "node.maxTrxCacheSize";
   public static final String NODE_ACTIVE = "node.active";
   public static final String NODE_PASSIVE = "node.passive";
   public static final String NODE_FAST_FORWARD = "node.fastForward";

--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -2065,9 +2065,13 @@ public class Manager {
     return chainBaseManager.getNullifierStore();
   }
 
+  public int getCachedTransactionSize() {
+    return pushTransactionQueue.size() + getPendingTransactions().size()
+        + getRePushTransactions().size();
+  }
+
   public boolean isTooManyPending() {
-    return getPendingTransactions().size() + getRePushTransactions().size()
-        > maxTransactionPendingSize;
+    return getCachedTransactionSize() > maxTransactionPendingSize;
   }
 
   private void preValidateTransactionSign(List<TransactionCapsule> txs)

--- a/framework/src/main/java/org/tron/core/net/TronNetDelegate.java
+++ b/framework/src/main/java/org/tron/core/net/TronNetDelegate.java
@@ -384,4 +384,8 @@ public class TronNetDelegate {
     return headNum - solidNum >= maxUnsolidifiedBlocks;
   }
 
+  public int getCachedTransactionSize() {
+    return dbManager.getCachedTransactionSize();
+  }
+
 }

--- a/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/TransactionsMsgHandler.java
@@ -31,7 +31,6 @@ import org.tron.protos.Protocol.Transaction.Contract.ContractType;
 @Component
 public class TransactionsMsgHandler implements TronMsgHandler {
 
-  private static int MAX_TRX_SIZE = 50_000;
   private static int MAX_SMART_CONTRACT_SUBMIT_SIZE = 100;
   @Autowired
   private TronNetDelegate tronNetDelegate;
@@ -40,7 +39,8 @@ public class TransactionsMsgHandler implements TronMsgHandler {
   @Autowired
   private ChainBaseManager chainBaseManager;
 
-  private BlockingQueue<TrxEvent> smartContractQueue = new LinkedBlockingQueue(MAX_TRX_SIZE);
+  private BlockingQueue<TrxEvent> smartContractQueue = new LinkedBlockingQueue(
+      Args.getInstance().getMaxTrxCacheSize());
 
   private BlockingQueue<Runnable> queue = new LinkedBlockingQueue();
 
@@ -63,7 +63,8 @@ public class TransactionsMsgHandler implements TronMsgHandler {
   }
 
   public boolean isBusy() {
-    return queue.size() + smartContractQueue.size() > MAX_TRX_SIZE;
+    return queue.size() + smartContractQueue.size()
+        + tronNetDelegate.getCachedTransactionSize() > Args.getInstance().getMaxTrxCacheSize();
   }
 
   @Override

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -163,6 +163,10 @@ node {
   fetchBlock.timeout = 200
   # syncFetchBatchNum = 2000
 
+  # Maximum total number of cached transactions (handler queues + pending + rePush).
+  # When exceeded, the node stops accepting TRX INV messages from peers.
+  # maxTrxCacheSize = 50000
+
   # Number of validate sign thread, default availableProcessors
   # validateSignThreadNum = 16
 

--- a/framework/src/test/java/org/tron/core/db/ManagerTest.java
+++ b/framework/src/test/java/org/tron/core/db/ManagerTest.java
@@ -16,12 +16,15 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -1300,6 +1303,56 @@ public class ManagerTest extends BaseMethodTest {
     TronError thrown = Assert.assertThrows(TronError.class, () ->
         manager.blockTrigger(new BlockCapsule(Block.newBuilder().build()), 1, 1));
     Assert.assertEquals(TronError.ErrCode.EVENT_SUBSCRIBE_ERROR, thrown.getErrCode());
+  }
+
+  @Test
+  public void testGetCachedTransactionSize() throws Exception {
+    BlockingQueue<TransactionCapsule> pushQ = new LinkedBlockingQueue<>();
+    pushQ.add(new TransactionCapsule(Protocol.Transaction.getDefaultInstance()));
+    Field pushField = Manager.class.getDeclaredField("pushTransactionQueue");
+    pushField.setAccessible(true);
+    pushField.set(dbManager, pushQ);
+
+    dbManager.getPendingTransactions().clear();
+    dbManager.getPendingTransactions().add(
+        new TransactionCapsule(Protocol.Transaction.getDefaultInstance()));
+    dbManager.getPendingTransactions().add(
+        new TransactionCapsule(Protocol.Transaction.getDefaultInstance()));
+
+    dbManager.getRePushTransactions().clear();
+
+    // 1 (push) + 2 (pending) + 0 (rePush) = 3
+    Assert.assertEquals(3, dbManager.getCachedTransactionSize());
+
+    // cleanup
+    pushQ.clear();
+    dbManager.getPendingTransactions().clear();
+  }
+
+  @Test
+  public void testIsTooManyPendingIncludesPushQueue() throws Exception {
+    int threshold = Args.getInstance().getMaxTransactionPendingSize();
+
+    BlockingQueue<TransactionCapsule> pushQ = new LinkedBlockingQueue<>();
+    Field pushField = Manager.class.getDeclaredField("pushTransactionQueue");
+    pushField.setAccessible(true);
+    pushField.set(dbManager, pushQ);
+
+    dbManager.getPendingTransactions().clear();
+    dbManager.getRePushTransactions().clear();
+
+    for (int i = 0; i < threshold; i++) {
+      dbManager.getPendingTransactions().add(
+          new TransactionCapsule(Protocol.Transaction.getDefaultInstance()));
+    }
+    Assert.assertFalse(dbManager.isTooManyPending());
+
+    pushQ.add(new TransactionCapsule(Protocol.Transaction.getDefaultInstance()));
+    Assert.assertTrue(dbManager.isTooManyPending());
+
+    // cleanup
+    dbManager.getPendingTransactions().clear();
+    pushQ.clear();
   }
 
   public void adjustBalance(AccountStore accountStore, byte[] accountAddress, long amount)

--- a/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/TransactionsMsgHandlerTest.java
@@ -42,8 +42,6 @@ public class TransactionsMsgHandlerTest extends BaseTest {
   public void testProcessMessage() {
     TransactionsMsgHandler transactionsMsgHandler = new TransactionsMsgHandler();
     try {
-      Assert.assertFalse(transactionsMsgHandler.isBusy());
-
       transactionsMsgHandler.init();
 
       PeerConnection peer = Mockito.mock(PeerConnection.class);
@@ -53,6 +51,8 @@ public class TransactionsMsgHandlerTest extends BaseTest {
       Field field = TransactionsMsgHandler.class.getDeclaredField("tronNetDelegate");
       field.setAccessible(true);
       field.set(transactionsMsgHandler, tronNetDelegate);
+
+      Assert.assertFalse(transactionsMsgHandler.isBusy());
 
       BalanceContract.TransferContract transferContract = BalanceContract.TransferContract
           .newBuilder()
@@ -130,6 +130,23 @@ public class TransactionsMsgHandlerTest extends BaseTest {
     } finally {
       transactionsMsgHandler.close();
     }
+  }
+
+  @Test
+  public void testIsBusyWithCachedTransactions() throws Exception {
+    TransactionsMsgHandler handler = new TransactionsMsgHandler();
+
+    TronNetDelegate tronNetDelegateMock = Mockito.mock(TronNetDelegate.class);
+    Mockito.when(tronNetDelegateMock.getCachedTransactionSize()).thenReturn(50_001);
+    Field field = TransactionsMsgHandler.class.getDeclaredField("tronNetDelegate");
+    field.setAccessible(true);
+    field.set(handler, tronNetDelegateMock);
+
+    // queue and smartContractQueue are empty, but cached size > threshold
+    Assert.assertTrue(handler.isBusy());
+
+    Mockito.when(tronNetDelegateMock.getCachedTransactionSize()).thenReturn(0);
+    Assert.assertFalse(handler.isBusy());
   }
 
   class TrxEvent {


### PR DESCRIPTION
…e check

1. Add Manager.getCachedTransactionSize() = pushTransactionQueue + pendingTransactions + rePushTransactions to expose the true cached transaction count across all three queues.

2. Fix isTooManyPending() to include pushTransactionQueue, which was previously omitted, causing the pending threshold to be underestimated.

3. Update TransactionsMsgHandler.isBusy() to factor in the Manager cache size via TronNetDelegate.getCachedTransactionSize(), so the node stops accepting TRX INV messages when the full pipeline is busy.

4. Make the busy threshold configurable via node.maxTrxCacheSize (default: 50000), replacing the hardcoded MAX_TRX_SIZE constant.

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

