### PR TITLE
feat(net): add HelloMessage timestamp validation and replay protection

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -301,6 +301,9 @@ public class CommonParameter {
   public int inactiveThreshold = 600; // from clearParam(), consistent with mainnet.conf
   @Getter
   @Setter
+  public int helloMsgTimestampThreshold = 1800;
+  @Getter
+  @Setter
   public boolean nodeDetectEnable;
   @Getter
   @Setter

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -627,6 +627,13 @@ public class Args extends CommonParameter {
       PARAMETER.inactiveThreshold = 1;
     }
 
+    PARAMETER.helloMsgTimestampThreshold =
+        config.hasPath(ConfigKey.NODE_HELLO_MSG_TIMESTAMP_THRESHOLD)
+            ? config.getInt(ConfigKey.NODE_HELLO_MSG_TIMESTAMP_THRESHOLD) : 1800;
+    if (PARAMETER.helloMsgTimestampThreshold < 1) {
+      PARAMETER.helloMsgTimestampThreshold = 1;
+    }
+
     PARAMETER.maxTransactionPendingSize =
         config.hasPath(ConfigKey.NODE_MAX_TRANSACTION_PENDING_SIZE)
             ? config.getInt(ConfigKey.NODE_MAX_TRANSACTION_PENDING_SIZE) : 2000;

--- a/framework/src/main/java/org/tron/core/config/args/ConfigKey.java
+++ b/framework/src/main/java/org/tron/core/config/args/ConfigKey.java
@@ -73,6 +73,8 @@ final class ConfigKey {
   // node - p2p
   public static final String NODE_LISTEN_PORT = "node.listen.port";
   public static final String NODE_P2P_VERSION = "node.p2p.version";
+  public static final String NODE_HELLO_MSG_TIMESTAMP_THRESHOLD =
+      "node.p2p.helloMsgTimestampThreshold";
   public static final String NODE_ENABLE_IPV6 = "node.enableIpv6";
   public static final String NODE_SYNC_FETCH_BATCH_NUM = "node.syncFetchBatchNum";
   public static final String NODE_MAX_TPS = "node.maxTps";

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -1,5 +1,7 @@
 package org.tron.core.net.service.relay;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.protobuf.ByteString;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -73,6 +75,13 @@ public class RelayService {
           .copyFrom(Args.getLocalWitnesses().getWitnessAccountAddress()) : null;
 
   private int maxFastForwardNum = Args.getInstance().getMaxFastForwardNum();
+
+  private final long timestampThreshold =
+      Args.getInstance().getHelloMsgTimestampThreshold() * 1000L;
+
+  private final Cache<ByteString, Long> helloReplayCache = CacheBuilder.newBuilder()
+      .maximumSize(100)
+      .build();
 
   public void init() {
     manager = ctx.getBean(Manager.class);
@@ -150,6 +159,20 @@ public class RelayService {
       return false;
     }
 
+    long now = System.currentTimeMillis();
+    if (now - msg.getTimestamp() > timestampThreshold) {
+      logger.warn("HelloMessage from {}, timestamp {} is stale, threshold {} ms",
+          channel.getInetAddress(), msg.getTimestamp(), timestampThreshold);
+      return false;
+    }
+
+    Long lastTimestamp = helloReplayCache.getIfPresent(msg.getAddress());
+    if (lastTimestamp != null && msg.getTimestamp() <= lastTimestamp) {
+      logger.warn("HelloMessage from {}, timestamp {} is not greater than last {}",
+          channel.getInetAddress(), msg.getTimestamp(), lastTimestamp);
+      return false;
+    }
+
     boolean flag;
     try {
       Sha256Hash hash = Sha256Hash.of(CommonParameter
@@ -166,13 +189,15 @@ public class RelayService {
         flag = Arrays.equals(sigAddress, witnessPermissionAddress);
       }
       if (flag) {
+        helloReplayCache.put(msg.getAddress(), msg.getTimestamp());
         TronNetService.getP2pConfig().getTrustNodes().add(channel.getInetAddress());
         DesensitizedConverter.addSensitive(channel.getInetAddress().toString().substring(1),
             ByteArray.toHexString(msg.getAddress().toByteArray()));
       }
       return flag;
     } catch (Exception e) {
-      logger.error("Check hello message failed, msg: {}, {}", message, channel.getInetAddress(), e);
+      logger.error("Check hello message failed, msg: {}, {}",
+          message, channel.getInetAddress(), e);
       return false;
     }
   }

--- a/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
@@ -73,6 +73,11 @@ public class RelayServiceTest extends BaseTest {
   @After
   public void clearPeers() {
     closePeer();
+    com.google.common.cache.Cache<?, ?> cache =
+        (com.google.common.cache.Cache<?, ?>) ReflectUtils.getFieldObject(service, "helloReplayCache");
+    if (cache != null) {
+      cache.invalidateAll();
+    }
   }
 
   @Test
@@ -225,6 +230,102 @@ public class RelayServiceTest extends BaseTest {
       logger.info("", e);
       assert false;
     }
+  }
+
+  private HelloMessage buildSignedHello(long timestamp) throws Exception {
+    String key = "0154435f065a57fec6af1e12eaa2fa600030639448d7809f4c65bdcf8baed7e5";
+    ByteString address = getFromHexString("418A8D690BF36806C36A7DAE3AF796643C1AA9CC01");
+    Node node = new Node(NetUtil.getNodeId(), "127.0.0.1", null, 10001);
+    HelloMessage msg = new HelloMessage(node, timestamp,
+        ChainBaseManager.getChainBaseManager());
+    SignInterface engine = SignUtils.fromPrivate(ByteArray.fromHexString(key),
+        Args.getInstance().isECKeyCryptoEngine());
+    ByteString sig = ByteString.copyFrom(engine.Base64toBytes(engine
+        .signHash(Sha256Hash.of(CommonParameter.getInstance()
+            .isECKeyCryptoEngine(), ByteArray.fromLong(timestamp)).getBytes())));
+    msg.setHelloMessage(msg.getHelloMessage().toBuilder()
+        .setAddress(address)
+        .setSignature(sig)
+        .build());
+    return msg;
+  }
+
+  private Channel buildChannel() {
+    InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10001);
+    Channel c = mock(Channel.class);
+    Mockito.when(c.getInetSocketAddress()).thenReturn(addr);
+    Mockito.when(c.getInetAddress()).thenReturn(addr.getAddress());
+    return c;
+  }
+
+  private void setupRelayServiceDeps() throws Exception {
+    Field f1 = service.getClass().getDeclaredField("witnessScheduleStore");
+    f1.setAccessible(true);
+    f1.set(service, chainBaseManager.getWitnessScheduleStore());
+    Field f2 = service.getClass().getDeclaredField("manager");
+    f2.setAccessible(true);
+    f2.set(service, dbManager);
+    ReflectUtils.setFieldValue(tronNetService, "p2pConfig", new P2pConfig());
+  }
+
+  @Test
+  public void testCheckHelloMessage_staleTimestamp() throws Exception {
+    initWitness();
+    setupRelayServiceDeps();
+    Args.getInstance().fastForward = true;
+    long threshold = Args.getInstance().getHelloMsgTimestampThreshold() * 1000L;
+    long staleTimestamp = System.currentTimeMillis() - threshold - 1000;
+    HelloMessage msg = buildSignedHello(staleTimestamp);
+    boolean result = service.checkHelloMessage(msg, buildChannel());
+    Assert.assertFalse(result);
+  }
+
+  @Test
+  public void testCheckHelloMessage_freshTimestamp() throws Exception {
+    initWitness();
+    setupRelayServiceDeps();
+    Args.getInstance().fastForward = true;
+    long freshTimestamp = System.currentTimeMillis();
+    HelloMessage msg = buildSignedHello(freshTimestamp);
+    boolean result = service.checkHelloMessage(msg, buildChannel());
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void testCheckHelloMessage_replayRejected() throws Exception {
+    initWitness();
+    setupRelayServiceDeps();
+    Args.getInstance().fastForward = true;
+    long t = System.currentTimeMillis();
+    HelloMessage msg1 = buildSignedHello(t);
+    Assert.assertTrue(service.checkHelloMessage(msg1, buildChannel()));
+    HelloMessage msg2 = buildSignedHello(t);
+    Assert.assertFalse(service.checkHelloMessage(msg2, buildChannel()));
+  }
+
+  @Test
+  public void testCheckHelloMessage_strictlyLargerTimestampPasses() throws Exception {
+    initWitness();
+    setupRelayServiceDeps();
+    Args.getInstance().fastForward = true;
+    long t = System.currentTimeMillis();
+    Assert.assertTrue(service.checkHelloMessage(buildSignedHello(t), buildChannel()));
+    Assert.assertTrue(service.checkHelloMessage(buildSignedHello(t + 1), buildChannel()));
+  }
+
+  @Test
+  public void testCheckHelloMessage_badSigDoesNotPoisonCache() throws Exception {
+    initWitness();
+    setupRelayServiceDeps();
+    Args.getInstance().fastForward = true;
+    long t = System.currentTimeMillis();
+    HelloMessage badMsg = buildSignedHello(t);
+    badMsg.setHelloMessage(badMsg.getHelloMessage().toBuilder()
+        .setSignature(ByteString.copyFrom(new byte[65]))
+        .build());
+    Assert.assertFalse(service.checkHelloMessage(badMsg, buildChannel()));
+    HelloMessage goodMsg = buildSignedHello(t);
+    Assert.assertTrue(service.checkHelloMessage(goodMsg, buildChannel()));
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**
Add HelloMessage timestamp validation and replay protection.
Reject stale HelloMessages exceeding configurable threshold (default 1800s) and replay attacks via monotonically-increasing timestamp cache per address.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**