### PR TITLE
feat(sync): reduce memory pressure by deferring block deserialization and throttling in-flight requests

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -146,6 +146,9 @@ public class CommonParameter {
   @Getter
   @Setter
   public long syncFetchBatchNum; // clearParam: 2000
+  @Getter
+  @Setter
+  public int maxPendingBlockNum;
 
   // If you are running a solidity node for java tron,
   // this flag is set to true

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -435,6 +435,15 @@ public class Args extends CommonParameter {
       PARAMETER.syncFetchBatchNum = 100;
     }
 
+    PARAMETER.maxPendingBlockNum = config.hasPath(ConfigKey.NODE_MAX_PENDING_BLOCK_NUM)
+        ? config.getInt(ConfigKey.NODE_MAX_PENDING_BLOCK_NUM) : 500;
+    if (PARAMETER.maxPendingBlockNum > 2000) {
+      PARAMETER.maxPendingBlockNum = 2000;
+    }
+    if (PARAMETER.maxPendingBlockNum < 50) {
+      PARAMETER.maxPendingBlockNum = 50;
+    }
+
     PARAMETER.rpcPort =
         config.hasPath(ConfigKey.NODE_RPC_PORT)
             ? config.getInt(ConfigKey.NODE_RPC_PORT) : 50051;

--- a/framework/src/main/java/org/tron/core/config/args/ConfigKey.java
+++ b/framework/src/main/java/org/tron/core/config/args/ConfigKey.java
@@ -75,6 +75,7 @@ final class ConfigKey {
   public static final String NODE_P2P_VERSION = "node.p2p.version";
   public static final String NODE_ENABLE_IPV6 = "node.enableIpv6";
   public static final String NODE_SYNC_FETCH_BATCH_NUM = "node.syncFetchBatchNum";
+  public static final String NODE_MAX_PENDING_BLOCK_NUM = "node.maxPendingBlockNum";
   public static final String NODE_MAX_TPS = "node.maxTps";
   public static final String NODE_NET_MAX_TRX_PER_SECOND = "node.netMaxTrxPerSecond";
   public static final String NODE_TCP_NETTY_WORK_THREAD_NUM = "node.tcpNettyWorkThreadNum";

--- a/framework/src/main/java/org/tron/core/net/service/sync/SyncService.java
+++ b/framework/src/main/java/org/tron/core/net/service/sync/SyncService.java
@@ -5,6 +5,7 @@ import static org.tron.core.config.Parameter.NetConstants.MAX_BLOCK_FETCH_PER_PE
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -44,9 +45,9 @@ public class SyncService {
   @Autowired
   private PbftDataSyncHandler pbftDataSyncHandler;
 
-  private Map<BlockMessage, PeerConnection> blockWaitToProcess = new ConcurrentHashMap<>();
+  private Map<UnparsedBlock, PeerConnection> blockWaitToProcess = new ConcurrentHashMap<>();
 
-  private Map<BlockMessage, PeerConnection> blockJustReceived = new ConcurrentHashMap<>();
+  private Map<UnparsedBlock, PeerConnection> blockJustReceived = new ConcurrentHashMap<>();
 
   private long blockCacheTimeout = Args.getInstance().getBlockCacheTimeout();
   private Cache<BlockId, PeerConnection> requestBlockIds = CacheBuilder.newBuilder()
@@ -68,6 +69,10 @@ public class SyncService {
   private volatile boolean fetchFlag = false;
 
   private final long syncFetchBatchNum = Args.getInstance().getSyncFetchBatchNum();
+
+  private final int maxPendingBlockNum = Args.getInstance().getMaxPendingBlockNum();
+
+  private static volatile long maxRequestedBlockNum = 0;
 
   public void init() {
     ExecutorServiceManager.scheduleWithFixedDelay(fetchExecutor, () -> {
@@ -135,7 +140,9 @@ public class SyncService {
 
   public void processBlock(PeerConnection peer, BlockMessage blockMessage) {
     synchronized (blockJustReceived) {
-      blockJustReceived.put(blockMessage, peer);
+      UnparsedBlock unparsedBlock = new UnparsedBlock(
+          blockMessage.getBlockId(), blockMessage.getData());
+      blockJustReceived.put(unparsedBlock, peer);
     }
     handleFlag = true;
     if (peer.isSyncIdle()) {
@@ -227,8 +234,18 @@ public class SyncService {
   }
 
   private void startFetchSyncBlock() {
+    Collection<PeerConnection> activePeers = tronNetDelegate.getActivePeer();
+    int reqNum = activePeers.stream()
+        .mapToInt(p -> p.getSyncBlockRequested().size()).sum();
+    int remainNum;
+    synchronized (blockJustReceived) {
+      remainNum = maxPendingBlockNum - reqNum
+          - blockJustReceived.size() - blockWaitToProcess.size();
+    }
+
     HashMap<PeerConnection, List<BlockId>> send = new HashMap<>();
-    tronNetDelegate.getActivePeer().stream()
+    int[] cnt = {0};
+    activePeers.stream()
         .filter(peer -> peer.isNeedSyncFromPeer() && peer.isSyncIdle())
         .filter(peer -> peer.isFetchAble())
         .forEach(peer -> {
@@ -238,9 +255,16 @@ public class SyncService {
           for (BlockId blockId : peer.getSyncBlockToFetch()) {
             if (requestBlockIds.getIfPresent(blockId) == null
                 && !peer.getSyncBlockInProcess().contains(blockId)) {
+              if (cnt[0] >= remainNum && blockId.getNum() > maxRequestedBlockNum) {
+                break;
+              }
+              if (blockId.getNum() > maxRequestedBlockNum) {
+                maxRequestedBlockNum = blockId.getNum();
+              }
               requestBlockIds.put(blockId, peer);
               peer.getSyncBlockRequested().put(blockId, System.currentTimeMillis());
               send.get(peer).add(blockId);
+              cnt[0]++;
               if (send.get(peer).size() >= MAX_BLOCK_FETCH_PER_PEER) {
                 break;
               }
@@ -269,29 +293,37 @@ public class SyncService {
 
       isProcessed[0] = false;
 
-      blockWaitToProcess.forEach((msg, peerConnection) -> {
+      blockWaitToProcess.forEach((unparsedBlock, peerConnection) -> {
         synchronized (tronNetDelegate.getBlockLock()) {
+          BlockId blockId = unparsedBlock.getBlockId();
           if (peerConnection.isDisconnect()) {
-            blockWaitToProcess.remove(msg);
-            invalid(msg.getBlockId(), peerConnection);
+            blockWaitToProcess.remove(unparsedBlock);
+            invalid(blockId, peerConnection);
             return;
           }
-          if (msg.getBlockId().getNum() <= solidNum) {
-            blockWaitToProcess.remove(msg);
-            peerConnection.getSyncBlockInProcess().remove(msg.getBlockId());
+          if (blockId.getNum() <= solidNum) {
+            blockWaitToProcess.remove(unparsedBlock);
+            peerConnection.getSyncBlockInProcess().remove(blockId);
             return;
           }
           final boolean[] isFound = {false};
           tronNetDelegate.getActivePeer().stream()
-              .filter(peer -> msg.getBlockId().equals(peer.getSyncBlockToFetch().peek()))
+              .filter(peer -> blockId.equals(peer.getSyncBlockToFetch().peek()))
               .forEach(peer -> {
                 isFound[0] = true;
               });
           if (isFound[0]) {
-            blockWaitToProcess.remove(msg);
+            blockWaitToProcess.remove(unparsedBlock);
             isProcessed[0] = true;
-            processSyncBlock(msg.getBlockCapsule(), peerConnection);
-            peerConnection.getSyncBlockInProcess().remove(msg.getBlockId());
+            BlockCapsule block;
+            try {
+              block = new BlockCapsule(unparsedBlock.getData());
+            } catch (Exception e) {
+              logger.warn("Deserialize block {} failed", blockId.getString(), e);
+              return;
+            }
+            processSyncBlock(block, peerConnection);
+            peerConnection.getSyncBlockInProcess().remove(blockId);
           }
         }
       });

--- a/framework/src/main/java/org/tron/core/net/service/sync/UnparsedBlock.java
+++ b/framework/src/main/java/org/tron/core/net/service/sync/UnparsedBlock.java
@@ -1,0 +1,46 @@
+package org.tron.core.net.service.sync;
+
+import org.tron.core.capsule.BlockCapsule;
+
+public class UnparsedBlock {
+
+  private final BlockCapsule.BlockId blockId;
+  private final byte[] data;
+
+  public UnparsedBlock(BlockCapsule.BlockId blockId, byte[] data) {
+    if (blockId == null) {
+      throw new IllegalArgumentException("blockId must not be null");
+    }
+    this.blockId = blockId;
+    this.data = data;
+  }
+
+  public BlockCapsule.BlockId getBlockId() {
+    return blockId;
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof UnparsedBlock)) {
+      return false;
+    }
+    return blockId.equals(((UnparsedBlock) o).blockId);
+  }
+
+  @Override
+  public int hashCode() {
+    return blockId.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return blockId.getString();
+  }
+}

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -163,6 +163,11 @@ node {
   fetchBlock.timeout = 200
   # syncFetchBatchNum = 2000
 
+  # Maximum number of blocks allowed in-flight (requested but not yet processed).
+  # Throttles block download to reduce memory pressure during sync.
+  # Range: [50, 2000], default: 500
+  # maxPendingBlockNum = 500
+
   # Number of validate sign thread, default availableProcessors
   # validateSignThreadNum = 16
 

--- a/framework/src/test/java/org/tron/core/net/services/SyncServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/SyncServiceTest.java
@@ -23,6 +23,7 @@ import org.tron.core.net.peer.PeerConnection;
 import org.tron.core.net.peer.PeerManager;
 import org.tron.core.net.peer.TronState;
 import org.tron.core.net.service.sync.SyncService;
+import org.tron.core.net.service.sync.UnparsedBlock;
 import org.tron.p2p.connection.Channel;
 import org.tron.protos.Protocol;
 
@@ -98,12 +99,22 @@ public class SyncServiceTest extends BaseMethodTest {
     ReflectUtils.setFieldValue(c1, "inetSocketAddress", inetSocketAddress);
     ReflectUtils.setFieldValue(c1, "inetAddress", inetSocketAddress.getAddress());
     peer.setChannel(c1);
-    service.processBlock(peer,
-            new BlockMessage(new BlockCapsule(Protocol.Block.newBuilder().build())));
+
+    BlockCapsule blockCapsule = new BlockCapsule(Protocol.Block.newBuilder().build());
+    BlockMessage blockMessage = new BlockMessage(blockCapsule);
+    service.processBlock(peer, blockMessage);
+
     boolean fetchFlag = (boolean) ReflectUtils.getFieldObject(service, "fetchFlag");
     boolean handleFlag = (boolean) ReflectUtils.getFieldObject(service, "handleFlag");
     Assert.assertTrue(fetchFlag);
     Assert.assertTrue(handleFlag);
+
+    Map<UnparsedBlock, PeerConnection> blockJustReceived =
+        (Map<UnparsedBlock, PeerConnection>)
+            ReflectUtils.getFieldObject(service, "blockJustReceived");
+    Assert.assertEquals(1, blockJustReceived.size());
+    UnparsedBlock stored = blockJustReceived.keySet().iterator().next();
+    Assert.assertEquals(blockMessage.getBlockId(), stored.getBlockId());
   }
 
   @Test
@@ -169,6 +180,33 @@ public class SyncServiceTest extends BaseMethodTest {
     peer.getSyncBlockRequested().remove(blockId);
     method.invoke(service);
     Assert.assertTrue(peer.getSyncBlockRequested().get(blockId) == null);
+
+    // reset static maxRequestedBlockNum to 0
+    Field maxRequestedBlockNumField = service.getClass().getDeclaredField("maxRequestedBlockNum");
+    maxRequestedBlockNumField.setAccessible(true);
+    maxRequestedBlockNumField.set(null, 0L);
+
+    Map<UnparsedBlock, PeerConnection> blockWaitToProcess =
+        (Map<UnparsedBlock, PeerConnection>)
+            ReflectUtils.getFieldObject(service, "blockWaitToProcess");
+
+    // target block has num=1, above maxRequestedBlockNum=0 so it can be throttled
+    BlockCapsule.BlockId highBlockId = new BlockCapsule.BlockId(Sha256Hash.ZERO_HASH, 1);
+    peer.getSyncBlockToFetch().clear();
+    peer.getSyncBlockToFetch().add(highBlockId);
+    peer.getSyncBlockRequested().clear();
+    requestBlockIds.invalidateAll();
+
+    // fill blockWaitToProcess to reach maxPendingBlockNum (default 500)
+    int maxPendingBlockNum = (int) ReflectUtils.getFieldObject(service, "maxPendingBlockNum");
+    for (int i = 0; i < maxPendingBlockNum; i++) {
+      BlockCapsule.BlockId fillId = new BlockCapsule.BlockId(Sha256Hash.ZERO_HASH, 10000 + i);
+      blockWaitToProcess.put(new UnparsedBlock(fillId, new byte[0]), peer);
+    }
+    method.invoke(service);
+    // highBlockId must NOT be requested: remainNum <= 0 and num > maxRequestedBlockNum
+    Assert.assertNull(peer.getSyncBlockRequested().get(highBlockId));
+    blockWaitToProcess.clear();
   }
 
   @Test
@@ -181,23 +219,18 @@ public class SyncServiceTest extends BaseMethodTest {
     Method method = service.getClass().getDeclaredMethod("handleSyncBlock");
     method.setAccessible(true);
 
-    Map<BlockMessage, PeerConnection> blockJustReceived =
-            (Map<BlockMessage, PeerConnection>)
+    Map<UnparsedBlock, PeerConnection> blockJustReceived =
+        (Map<UnparsedBlock, PeerConnection>)
             ReflectUtils.getFieldObject(service, "blockJustReceived");
-    Protocol.BlockHeader.raw.Builder blockHeaderRawBuild = Protocol.BlockHeader.raw.newBuilder();
-    Protocol.BlockHeader.raw blockHeaderRaw = blockHeaderRawBuild
+
+    Protocol.BlockHeader.raw blockHeaderRaw = Protocol.BlockHeader.raw.newBuilder()
         .setNumber(100000)
         .build();
-
-    // block header
-    Protocol.BlockHeader.Builder blockHeaderBuild = Protocol.BlockHeader.newBuilder();
-    Protocol.BlockHeader blockHeader = blockHeaderBuild.setRawData(blockHeaderRaw).build();
-
-    BlockCapsule blockCapsule = new BlockCapsule(Protocol.Block.newBuilder()
-        .setBlockHeader(blockHeader).build());
-
+    Protocol.BlockHeader blockHeader = Protocol.BlockHeader.newBuilder()
+        .setRawData(blockHeaderRaw).build();
+    BlockCapsule blockCapsule = new BlockCapsule(
+        Protocol.Block.newBuilder().setBlockHeader(blockHeader).build());
     BlockCapsule.BlockId blockId = blockCapsule.getBlockId();
-
 
     InetSocketAddress a1 = new InetSocketAddress("127.0.0.1", 10001);
     Channel c1 = mock(Channel.class);
@@ -206,14 +239,14 @@ public class SyncServiceTest extends BaseMethodTest {
     PeerManager.add(ctx, c1);
     peer = PeerManager.getPeers().get(0);
 
-    blockJustReceived.put(new BlockMessage(blockCapsule), peer);
+    UnparsedBlock unparsedBlock = new UnparsedBlock(blockId, blockCapsule.getData());
+    blockJustReceived.put(unparsedBlock, peer);
 
     peer.getSyncBlockToFetch().add(blockId);
 
     Cache<BlockCapsule.BlockId, PeerConnection> requestBlockIds =
-            (Cache<BlockCapsule.BlockId, PeerConnection>)
-                    ReflectUtils.getFieldObject(service, "requestBlockIds");
-
+        (Cache<BlockCapsule.BlockId, PeerConnection>)
+            ReflectUtils.getFieldObject(service, "requestBlockIds");
     requestBlockIds.put(blockId, peer);
 
     method.invoke(service);


### PR DESCRIPTION
Introducing UnparsedBlock, the synchronization queue only stores blockId + byte[], and deserialization is delayed until the block reaches the head of the processing queue, eliminating the memory and GC pressure caused by a large number of BlockCapsule object trees in the queue.

Adding the node.maxPendingBlockNum configuration parameter (default 500, range [50, 2000]), the maxRequestedBlockNum high-water mark mechanism limits the total number of blocks in transit, while ensuring that low-height blocks (timeout retries) can always bypass the rate limit.

Updated SyncServiceTest to cover UnparsedBlock queue semantics and throttle logic.

## Test Plan
- [x] Checkstyle 通过
- [x] `SyncServiceTest` 全部 5 个测试通过
- [ ] 手动验证（节点同步场景）