### PR TITLE
fix: limit incoming gRPC connections

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -215,6 +215,12 @@ public class CommonParameter {
   public int maxConcurrentCallsPerConnection;
   @Getter
   @Setter
+  public int rpcMaxConnections;
+  @Getter
+  @Setter
+  public int rpcMaxConnectionsPerIp;
+  @Getter
+  @Setter
   public int flowControlWindow;
   @Getter
   @Setter

--- a/common/src/main/java/org/tron/core/config/README.md
+++ b/common/src/main/java/org/tron/core/config/README.md
@@ -58,6 +58,14 @@ node {
     # default 100. Setting 0 also uses the secure default.
     # maxConcurrentCallsPerConnection = 100
 
+    # Maximum active incoming gRPC connections shared by all gRPC API ports,
+    # default 512. Setting 0 also uses the secure default.
+    # maxConnections = 512
+
+    # Maximum active incoming gRPC connections from one remote IP address,
+    # default 32. Setting 0 also uses the secure default.
+    # maxConnectionsPerIp = 32
+
     # The HTTP/2 flow control window, default 1MB
     # flowControlWindow =
 
@@ -79,6 +87,10 @@ node {
 > **Upgrade note:** `maxConcurrentCallsPerConnection = 0` previously disabled the limit.
 > It now selects the secure default of 100. Configure an explicit positive value if a node
 > requires more than 100 concurrent calls on one connection.
+
+`maxConnections` is shared by the FullNode, Solidity, and PBFT gRPC ports. When a proxy is placed
+in front of java-tron, `maxConnectionsPerIp` observes the proxy's source address; enforce the
+client-IP limit at the proxy or preserve the original source address.
 
 ## backup
 You can customize backup options in the `node.backup` part of `config.conf`, which looks like:

--- a/common/src/main/java/org/tron/core/config/args/NodeConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/NodeConfig.java
@@ -208,6 +208,8 @@ public class NodeConfig {
   public static class RpcConfig {
 
     public static final int DEFAULT_MAX_CONCURRENT_CALLS_PER_CONNECTION = 100;
+    public static final int DEFAULT_MAX_CONNECTIONS = 512;
+    public static final int DEFAULT_MAX_CONNECTIONS_PER_IP = 32;
 
     private boolean enable = true;
     private int port = 50051;
@@ -219,6 +221,8 @@ public class NodeConfig {
     private int thread = 0;
     private int maxConcurrentCallsPerConnection =
         DEFAULT_MAX_CONCURRENT_CALLS_PER_CONNECTION;
+    private int maxConnections = DEFAULT_MAX_CONNECTIONS;
+    private int maxConnectionsPerIp = DEFAULT_MAX_CONNECTIONS_PER_IP;
     private int flowControlWindow = 1048576;
     private long maxConnectionIdleInMillis = 0;
     private long maxConnectionAgeInMillis = 0;
@@ -372,6 +376,28 @@ public class NodeConfig {
           RpcConfig.DEFAULT_MAX_CONCURRENT_CALLS_PER_CONNECTION);
       rpc.maxConcurrentCallsPerConnection =
           RpcConfig.DEFAULT_MAX_CONCURRENT_CALLS_PER_CONNECTION;
+    }
+    if (rpc.maxConnections < 0) {
+      throw new TronError("node.rpc.maxConnections must be non-negative, got: "
+          + rpc.maxConnections, PARAMETER_INIT);
+    }
+    if (rpc.maxConnections == 0) {
+      logger.warn("Configuring [node.rpc.maxConnections] as 0 uses the secure default of {}.",
+          RpcConfig.DEFAULT_MAX_CONNECTIONS);
+      rpc.maxConnections = RpcConfig.DEFAULT_MAX_CONNECTIONS;
+    }
+    if (rpc.maxConnectionsPerIp < 0) {
+      throw new TronError("node.rpc.maxConnectionsPerIp must be non-negative, got: "
+          + rpc.maxConnectionsPerIp, PARAMETER_INIT);
+    }
+    if (rpc.maxConnectionsPerIp == 0) {
+      logger.warn("Configuring [node.rpc.maxConnectionsPerIp] as 0 uses the secure default of {}.",
+          RpcConfig.DEFAULT_MAX_CONNECTIONS_PER_IP);
+      rpc.maxConnectionsPerIp = RpcConfig.DEFAULT_MAX_CONNECTIONS_PER_IP;
+    }
+    if (rpc.maxConnectionsPerIp > rpc.maxConnections) {
+      throw new TronError("node.rpc.maxConnectionsPerIp must not exceed node.rpc.maxConnections, "
+          + "got: " + rpc.maxConnectionsPerIp + " > " + rpc.maxConnections, PARAMETER_INIT);
     }
     if (rpc.maxConnectionIdleInMillis == 0) {
       rpc.maxConnectionIdleInMillis = Long.MAX_VALUE;

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -292,6 +292,14 @@ node {
     # Maximum concurrent calls per incoming connection. 0 falls back to the secure default of 100.
     maxConcurrentCallsPerConnection = 100
 
+    # Maximum active incoming gRPC connections shared by all gRPC API ports.
+    # 0 falls back to the secure default of 512.
+    maxConnections = 512
+
+    # Maximum active incoming gRPC connections from one remote IP address.
+    # 0 falls back to the secure default of 32. Must not exceed maxConnections.
+    maxConnectionsPerIp = 32
+
     # HTTP/2 flow control window (bytes), default 1MB
     flowControlWindow = 1048576
 

--- a/common/src/test/java/org/tron/core/config/args/NodeConfigTest.java
+++ b/common/src/test/java/org/tron/core/config/args/NodeConfigTest.java
@@ -106,6 +106,9 @@ public class NodeConfigTest {
     // reference.conf provides actual final defaults, no sentinel conversion needed
     assertEquals(NodeConfig.RpcConfig.DEFAULT_MAX_CONCURRENT_CALLS_PER_CONNECTION,
         rpc.getMaxConcurrentCallsPerConnection());
+    assertEquals(NodeConfig.RpcConfig.DEFAULT_MAX_CONNECTIONS, rpc.getMaxConnections());
+    assertEquals(NodeConfig.RpcConfig.DEFAULT_MAX_CONNECTIONS_PER_IP,
+        rpc.getMaxConnectionsPerIp());
     assertEquals(1048576, rpc.getFlowControlWindow());
     assertEquals(9223372036854775807L, rpc.getMaxConnectionIdleInMillis());
     assertEquals(9223372036854775807L, rpc.getMaxConnectionAgeInMillis());
@@ -147,10 +150,48 @@ public class NodeConfigTest {
   }
 
   @Test
+  public void testRpcZeroConnectionLimitsUseSecureDefaults() {
+    Config config = withRef(
+        "node { rpc { maxConnections = 0, maxConnectionsPerIp = 0 } }");
+    NodeConfig.RpcConfig rpc = NodeConfig.fromConfig(config).getRpc();
+
+    assertEquals(NodeConfig.RpcConfig.DEFAULT_MAX_CONNECTIONS, rpc.getMaxConnections());
+    assertEquals(NodeConfig.RpcConfig.DEFAULT_MAX_CONNECTIONS_PER_IP,
+        rpc.getMaxConnectionsPerIp());
+  }
+
+  @Test
+  public void testRpcNegativeConnectionLimitsRejected() {
+    TronError maxConnectionsException = assertThrows(TronError.class,
+        () -> NodeConfig.fromConfig(withRef("node.rpc.maxConnections = -1")));
+    assertTrue(maxConnectionsException.getMessage().contains(
+        "node.rpc.maxConnections must be non-negative, got: -1"));
+
+    TronError perIpException = assertThrows(TronError.class,
+        () -> NodeConfig.fromConfig(withRef("node.rpc.maxConnectionsPerIp = -1")));
+    assertTrue(perIpException.getMessage().contains(
+        "node.rpc.maxConnectionsPerIp must be non-negative, got: -1"));
+  }
+
+  @Test
+  public void testRpcPerIpConnectionLimitCannotExceedGlobalLimit() {
+    Config config = withRef(
+        "node { rpc { maxConnections = 10, maxConnectionsPerIp = 11 } }");
+
+    TronError exception = assertThrows(TronError.class,
+        () -> NodeConfig.fromConfig(config));
+
+    assertTrue(exception.getMessage().contains(
+        "node.rpc.maxConnectionsPerIp must not exceed node.rpc.maxConnections, got: 11 > 10"));
+  }
+
+  @Test
   public void testRpcUserOverrideExplicitValues() {
     Config config = withRef(
         "node { rpc { thread = 32,"
             + " maxConcurrentCallsPerConnection = 50,"
+            + " maxConnections = 256,"
+            + " maxConnectionsPerIp = 16,"
             + " flowControlWindow = 2097152,"
             + " maxMessageSize = 8388608,"
             + " maxHeaderListSize = 16384 } }");
@@ -158,6 +199,8 @@ public class NodeConfigTest {
     NodeConfig.RpcConfig rpc = nc.getRpc();
     assertEquals(32, rpc.getThread());
     assertEquals(50, rpc.getMaxConcurrentCallsPerConnection());
+    assertEquals(256, rpc.getMaxConnections());
+    assertEquals(16, rpc.getMaxConnectionsPerIp());
     assertEquals(2097152, rpc.getFlowControlWindow());
     assertEquals(8388608, rpc.getMaxMessageSize());
     assertEquals(16384, rpc.getMaxHeaderListSize());

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,10 @@ node {
     solidityPort = 50061
     # Maximum concurrent calls per connection. 0 uses the secure default of 100.
     maxConcurrentCallsPerConnection = 100
+    # Maximum active connections shared by all gRPC ports. 0 uses the secure default of 512.
+    maxConnections = 512
+    # Maximum active connections per remote IP. 0 uses the secure default of 32.
+    maxConnectionsPerIp = 32
     # Idle connection timeout (ms). 0 = no limit.
     maxConnectionIdleInMillis = 0
     # Minimum active connections required before broadcasting transactions.
@@ -117,6 +121,10 @@ node {
 > **Upgrade note:** `node.rpc.maxConcurrentCallsPerConnection = 0` previously meant no limit.
 > It now selects the secure default of 100. Configure an explicit positive value if a client
 > needs more than 100 concurrent calls on one connection.
+
+The gRPC connection limits are enforced before HTTP/2 request processing. `maxConnections` is
+shared by all java-tron gRPC ports. If a reverse proxy hides client source addresses, configure
+the per-client connection limit at the proxy instead.
 
 To disable an API endpoint that you do not want to expose publicly, set its `Enable` flag to `false` or add endpoints to `node.disabledApi`:
 

--- a/framework/src/main/java/org/tron/common/application/GrpcConnectionLimiter.java
+++ b/framework/src/main/java/org/tron/common/application/GrpcConnectionLimiter.java
@@ -1,0 +1,165 @@
+/*
+ * java-tron is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * java-tron is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with java-tron.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.tron.common.application;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Limits active incoming gRPC connections across all gRPC server ports. */
+final class GrpcConnectionLimiter {
+
+  private final AtomicInteger activeConnections = new AtomicInteger();
+  private final ConcurrentMap<InetAddress, Integer> activeConnectionsByIp =
+      new ConcurrentHashMap<>();
+
+  ChannelHandler newHandler(
+      ChannelHandler delegate, int maxConnections, int maxConnectionsPerIp) {
+    checkNotNull(delegate, "delegate");
+    checkArgument(maxConnections > 0, "maxConnections must be positive");
+    checkArgument(maxConnectionsPerIp > 0, "maxConnectionsPerIp must be positive");
+    checkArgument(maxConnectionsPerIp <= maxConnections,
+        "maxConnectionsPerIp must not exceed maxConnections");
+    return new ConnectionAdmissionHandler(
+        delegate, this, maxConnections, maxConnectionsPerIp);
+  }
+
+  Permit tryAcquire(
+      SocketAddress remoteAddress, int maxConnections, int maxConnectionsPerIp) {
+    if (!tryIncrement(activeConnections, maxConnections)) {
+      return null;
+    }
+
+    InetAddress remoteIp = remoteIp(remoteAddress);
+    if (remoteIp != null && !tryIncrement(remoteIp, maxConnectionsPerIp)) {
+      activeConnections.decrementAndGet();
+      return null;
+    }
+    return new Permit(this, remoteIp);
+  }
+
+  int activeConnections() {
+    return activeConnections.get();
+  }
+
+  int activeConnections(InetAddress remoteIp) {
+    return activeConnectionsByIp.getOrDefault(remoteIp, 0);
+  }
+
+  private boolean tryIncrement(InetAddress remoteIp, int maxConnectionsPerIp) {
+    AtomicBoolean acquired = new AtomicBoolean();
+    activeConnectionsByIp.compute(remoteIp, (ignored, current) -> {
+      int count = current == null ? 0 : current;
+      if (count >= maxConnectionsPerIp) {
+        return current;
+      }
+      acquired.set(true);
+      return count + 1;
+    });
+    return acquired.get();
+  }
+
+  private static boolean tryIncrement(AtomicInteger counter, int limit) {
+    while (true) {
+      int current = counter.get();
+      if (current >= limit) {
+        return false;
+      }
+      if (counter.compareAndSet(current, current + 1)) {
+        return true;
+      }
+    }
+  }
+
+  private void release(InetAddress remoteIp) {
+    if (remoteIp != null) {
+      activeConnectionsByIp.compute(remoteIp, (ignored, current) -> {
+        if (current == null || current <= 1) {
+          return null;
+        }
+        return current - 1;
+      });
+    }
+    activeConnections.decrementAndGet();
+  }
+
+  private static InetAddress remoteIp(SocketAddress remoteAddress) {
+    if (!(remoteAddress instanceof InetSocketAddress)) {
+      return null;
+    }
+    return ((InetSocketAddress) remoteAddress).getAddress();
+  }
+
+  static final class Permit {
+
+    private final GrpcConnectionLimiter limiter;
+    private final InetAddress remoteIp;
+    private final AtomicBoolean released = new AtomicBoolean();
+
+    private Permit(GrpcConnectionLimiter limiter, InetAddress remoteIp) {
+      this.limiter = limiter;
+      this.remoteIp = remoteIp;
+    }
+
+    void release() {
+      if (released.compareAndSet(false, true)) {
+        limiter.release(remoteIp);
+      }
+    }
+  }
+
+  private static final class ConnectionAdmissionHandler extends ChannelInboundHandlerAdapter {
+
+    private final ChannelHandler delegate;
+    private final GrpcConnectionLimiter limiter;
+    private final int maxConnections;
+    private final int maxConnectionsPerIp;
+
+    private ConnectionAdmissionHandler(
+        ChannelHandler delegate,
+        GrpcConnectionLimiter limiter,
+        int maxConnections,
+        int maxConnectionsPerIp) {
+      this.delegate = delegate;
+      this.limiter = limiter;
+      this.maxConnections = maxConnections;
+      this.maxConnectionsPerIp = maxConnectionsPerIp;
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+      Permit permit = limiter.tryAcquire(
+          ctx.channel().remoteAddress(), maxConnections, maxConnectionsPerIp);
+      if (permit == null) {
+        ctx.close();
+        return;
+      }
+
+      ctx.channel().closeFuture().addListener(ignored -> permit.release());
+      ctx.pipeline().addAfter(ctx.name(), null, delegate);
+    }
+  }
+}

--- a/framework/src/main/java/org/tron/common/application/GrpcNettyMaxConcurrentStreamsLimiter.java
+++ b/framework/src/main/java/org/tron/common/application/GrpcNettyMaxConcurrentStreamsLimiter.java
@@ -25,26 +25,42 @@ import io.grpc.netty.NettyServerBuilder;
 import io.netty.channel.ChannelHandler;
 import io.netty.util.AsciiString;
 
-/** Enforces the advertised HTTP/2 concurrent stream limit for grpc-netty servers. */
+/** Configures stream enforcement and connection admission for grpc-netty servers. */
 final class GrpcNettyMaxConcurrentStreamsLimiter {
 
   private GrpcNettyMaxConcurrentStreamsLimiter() {
   }
 
   static NettyServerBuilder configurePlaintext(
-      NettyServerBuilder builder, int maxConcurrentStreams) {
+      NettyServerBuilder builder,
+      int maxConcurrentStreams,
+      GrpcConnectionLimiter connectionLimiter,
+      int maxConnections,
+      int maxConnectionsPerIp) {
     checkNotNull(builder, "builder");
+    checkNotNull(connectionLimiter, "connectionLimiter");
     checkArgument(maxConcurrentStreams > 0, "maxConcurrentStreams must be positive");
     builder.maxConcurrentCallsPerConnection(maxConcurrentStreams);
     // TODO: Remove this shim after https://github.com/grpc/grpc-java/issues/12930 is fixed.
-    return builder.protocolNegotiator(newPlaintextNegotiator(maxConcurrentStreams));
+    return builder.protocolNegotiator(newPlaintextNegotiator(
+        maxConcurrentStreams, connectionLimiter, maxConnections, maxConnectionsPerIp));
   }
 
   static InternalProtocolNegotiator.ProtocolNegotiator newPlaintextNegotiator(
       int maxConcurrentStreams) {
+    return newPlaintextNegotiator(
+        maxConcurrentStreams, new GrpcConnectionLimiter(), Integer.MAX_VALUE, Integer.MAX_VALUE);
+  }
+
+  static InternalProtocolNegotiator.ProtocolNegotiator newPlaintextNegotiator(
+      int maxConcurrentStreams,
+      GrpcConnectionLimiter connectionLimiter,
+      int maxConnections,
+      int maxConnectionsPerIp) {
     checkArgument(maxConcurrentStreams > 0, "maxConcurrentStreams must be positive");
     return new EnforcingProtocolNegotiator(
-        InternalProtocolNegotiators.serverPlaintext(), maxConcurrentStreams);
+        InternalProtocolNegotiators.serverPlaintext(), maxConcurrentStreams,
+        connectionLimiter, maxConnections, maxConnectionsPerIp);
   }
 
   private static final class EnforcingProtocolNegotiator
@@ -52,11 +68,21 @@ final class GrpcNettyMaxConcurrentStreamsLimiter {
 
     private final InternalProtocolNegotiator.ProtocolNegotiator delegate;
     private final int maxConcurrentStreams;
+    private final GrpcConnectionLimiter connectionLimiter;
+    private final int maxConnections;
+    private final int maxConnectionsPerIp;
 
     private EnforcingProtocolNegotiator(
-        InternalProtocolNegotiator.ProtocolNegotiator delegate, int maxConcurrentStreams) {
+        InternalProtocolNegotiator.ProtocolNegotiator delegate,
+        int maxConcurrentStreams,
+        GrpcConnectionLimiter connectionLimiter,
+        int maxConnections,
+        int maxConnectionsPerIp) {
       this.delegate = checkNotNull(delegate, "delegate");
       this.maxConcurrentStreams = maxConcurrentStreams;
+      this.connectionLimiter = checkNotNull(connectionLimiter, "connectionLimiter");
+      this.maxConnections = maxConnections;
+      this.maxConnectionsPerIp = maxConnectionsPerIp;
     }
 
     @Override
@@ -68,7 +94,8 @@ final class GrpcNettyMaxConcurrentStreamsLimiter {
     public ChannelHandler newHandler(GrpcHttp2ConnectionHandler grpcHandler) {
       // grpc-java builds the connection directly, bypassing Netty's builder-side enforcement.
       grpcHandler.connection().remote().maxActiveStreams(maxConcurrentStreams);
-      return delegate.newHandler(grpcHandler);
+      return connectionLimiter.newHandler(
+          delegate.newHandler(grpcHandler), maxConnections, maxConnectionsPerIp);
     }
 
     @Override

--- a/framework/src/main/java/org/tron/common/application/RpcService.java
+++ b/framework/src/main/java/org/tron/common/application/RpcService.java
@@ -34,6 +34,8 @@ import org.tron.core.services.ratelimiter.RpcApiAccessInterceptor;
 @Slf4j(topic = "rpc")
 public abstract class RpcService extends AbstractService {
 
+  private static final GrpcConnectionLimiter CONNECTION_LIMITER = new GrpcConnectionLimiter();
+
   private Server apiServer;
   private ExecutorService executorService;
   protected String executorName;
@@ -101,7 +103,11 @@ public abstract class RpcService extends AbstractService {
     }
     // Set configs from config.conf or default value
     serverBuilder = GrpcNettyMaxConcurrentStreamsLimiter.configurePlaintext(
-        serverBuilder, parameter.getMaxConcurrentCallsPerConnection());
+        serverBuilder,
+        parameter.getMaxConcurrentCallsPerConnection(),
+        connectionLimiter(),
+        parameter.getRpcMaxConnections(),
+        parameter.getRpcMaxConnectionsPerIp());
     serverBuilder
         .flowControlWindow(parameter.getFlowControlWindow())
         .maxConnectionIdle(parameter.getMaxConnectionIdleInMillis(), TimeUnit.MILLISECONDS)
@@ -117,6 +123,10 @@ public abstract class RpcService extends AbstractService {
       serverBuilder.addService(ProtoReflectionService.newInstance());
     }
     return serverBuilder;
+  }
+
+  GrpcConnectionLimiter connectionLimiter() {
+    return CONNECTION_LIMITER;
   }
 
   protected abstract void addService(NettyServerBuilder serverBuilder);

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -523,6 +523,8 @@ public class Args extends CommonParameter {
     PARAMETER.rpcOnPBFTPort = rpc.getPBFTPort();
     PARAMETER.rpcThreadNum = rpc.getThread();
     PARAMETER.maxConcurrentCallsPerConnection = rpc.getMaxConcurrentCallsPerConnection();
+    PARAMETER.rpcMaxConnections = rpc.getMaxConnections();
+    PARAMETER.rpcMaxConnectionsPerIp = rpc.getMaxConnectionsPerIp();
     PARAMETER.flowControlWindow = rpc.getFlowControlWindow();
     PARAMETER.rpcMaxRstStream = rpc.getMaxRstStream();
     PARAMETER.rpcSecondsPerWindow = rpc.getSecondsPerWindow();
@@ -1315,4 +1317,3 @@ public class Args extends CommonParameter {
     return optionGroupMap;
   }
 }
-

--- a/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
+++ b/framework/src/main/java/org/tron/core/services/http/JsonFormat.java
@@ -58,7 +58,6 @@ import org.tron.common.utils.ByteArray;
 import org.tron.common.utils.Commons;
 import org.tron.common.utils.StringUtil;
 import org.tron.core.Constant;
-import org.tron.json.JSON;
 import org.tron.protos.contract.BalanceContract;
 
 /**
@@ -866,14 +865,10 @@ public class JsonFormat {
     }
     //Normal String
     if (HttpSelfFormatFieldName.isNameStringFormat(fliedName)) {
-      String result = new String(input.toByteArray());
-      result = result.replaceAll("\"", "\\\\\"");
-      try {
-        JSON.parseObject("{\"key\":\"" + result + "\"}");
-        return result;
-      } catch (Exception e) {
+      if (!input.isValidUtf8()) {
         return ByteArray.toHexString(input.toByteArray());
       }
+      return escapeText(input.toStringUtf8());
     }
     //HEX
     return ByteArray.toHexString(input.toByteArray());

--- a/framework/src/main/resources/config.conf
+++ b/framework/src/main/resources/config.conf
@@ -133,6 +133,12 @@ node {
     PBFTEnable = true
     PBFTPort = 50071
 
+    # Maximum active incoming gRPC connections shared by all gRPC API ports.
+    maxConnections = 512
+
+    # Maximum active incoming gRPC connections from one remote IP address.
+    maxConnectionsPerIp = 32
+
     maxConnectionIdleInMillis = 60000
     minEffectiveConnection = 1
 

--- a/framework/src/test/java/org/tron/common/application/GrpcConnectionLimiterTest.java
+++ b/framework/src/test/java/org/tron/common/application/GrpcConnectionLimiterTest.java
@@ -1,0 +1,149 @@
+/*
+ * java-tron is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * java-tron is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with java-tron.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.tron.common.application;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+public class GrpcConnectionLimiterTest {
+
+  @Test
+  public void shouldEnforceGlobalLimitAcrossRemoteIps() throws Exception {
+    GrpcConnectionLimiter limiter = new GrpcConnectionLimiter();
+    InetAddress firstIp = InetAddress.getByName("192.0.2.1");
+    InetAddress secondIp = InetAddress.getByName("192.0.2.2");
+    InetAddress thirdIp = InetAddress.getByName("192.0.2.3");
+
+    GrpcConnectionLimiter.Permit first = limiter.tryAcquire(
+        new InetSocketAddress(firstIp, 10001), 2, 2);
+    GrpcConnectionLimiter.Permit second = limiter.tryAcquire(
+        new InetSocketAddress(secondIp, 10002), 2, 2);
+
+    assertNotNull(first);
+    assertNotNull(second);
+    assertNull(limiter.tryAcquire(new InetSocketAddress(thirdIp, 10003), 2, 2));
+    assertEquals(2, limiter.activeConnections());
+
+    first.release();
+    second.release();
+    assertEquals(0, limiter.activeConnections());
+  }
+
+  @Test
+  public void shouldEnforcePerIpLimitAndAllowOtherIps() throws Exception {
+    GrpcConnectionLimiter limiter = new GrpcConnectionLimiter();
+    InetAddress firstIp = InetAddress.getByName("192.0.2.10");
+    InetAddress secondIp = InetAddress.getByName("192.0.2.11");
+
+    GrpcConnectionLimiter.Permit first = limiter.tryAcquire(
+        new InetSocketAddress(firstIp, 10001), 3, 1);
+
+    assertNotNull(first);
+    assertNull(limiter.tryAcquire(new InetSocketAddress(firstIp, 10002), 3, 1));
+    GrpcConnectionLimiter.Permit second = limiter.tryAcquire(
+        new InetSocketAddress(secondIp, 10003), 3, 1);
+    assertNotNull(second);
+    assertEquals(1, limiter.activeConnections(firstIp));
+    assertEquals(1, limiter.activeConnections(secondIp));
+
+    first.release();
+    second.release();
+    assertEquals(0, limiter.activeConnections(firstIp));
+    assertEquals(0, limiter.activeConnections(secondIp));
+  }
+
+  @Test
+  public void shouldReleasePermitOnlyOnceAndAllowReplacementConnection() throws Exception {
+    GrpcConnectionLimiter limiter = new GrpcConnectionLimiter();
+    InetAddress remoteIp = InetAddress.getByName("192.0.2.20");
+    InetSocketAddress remoteAddress = new InetSocketAddress(remoteIp, 10001);
+    GrpcConnectionLimiter.Permit first = limiter.tryAcquire(remoteAddress, 1, 1);
+
+    assertNotNull(first);
+    first.release();
+    first.release();
+    assertEquals(0, limiter.activeConnections());
+
+    GrpcConnectionLimiter.Permit replacement = limiter.tryAcquire(remoteAddress, 1, 1);
+    assertNotNull(replacement);
+    replacement.release();
+    assertEquals(0, limiter.activeConnections());
+  }
+
+  @Test
+  public void shouldNotExceedLimitDuringConcurrentAdmissions() throws Exception {
+    int maxConnections = 8;
+    int attempts = 64;
+    GrpcConnectionLimiter limiter = new GrpcConnectionLimiter();
+    InetAddress remoteIp = InetAddress.getByName("192.0.2.30");
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch attempted = new CountDownLatch(attempts);
+    CountDownLatch release = new CountDownLatch(1);
+    AtomicInteger admitted = new AtomicInteger();
+    ExecutorService executor = Executors.newFixedThreadPool(32);
+    List<Future<?>> futures = new ArrayList<>();
+
+    try {
+      for (int i = 0; i < attempts; i++) {
+        int port = 10000 + i;
+        futures.add(executor.submit(() -> {
+          start.await();
+          GrpcConnectionLimiter.Permit permit = limiter.tryAcquire(
+              new InetSocketAddress(remoteIp, port), maxConnections, maxConnections);
+          if (permit != null) {
+            admitted.incrementAndGet();
+          }
+          attempted.countDown();
+          if (permit != null) {
+            release.await();
+            permit.release();
+          }
+          return null;
+        }));
+      }
+
+      start.countDown();
+      assertTrue(attempted.await(5, TimeUnit.SECONDS));
+      assertEquals(maxConnections, admitted.get());
+      assertEquals(maxConnections, limiter.activeConnections());
+      assertEquals(maxConnections, limiter.activeConnections(remoteIp));
+      release.countDown();
+      for (Future<?> future : futures) {
+        future.get(5, TimeUnit.SECONDS);
+      }
+      assertEquals(0, limiter.activeConnections());
+      assertEquals(0, limiter.activeConnections(remoteIp));
+    } finally {
+      release.countDown();
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    }
+  }
+}

--- a/framework/src/test/java/org/tron/common/application/RpcServiceHttp2SecurityTest.java
+++ b/framework/src/test/java/org/tron/common/application/RpcServiceHttp2SecurityTest.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
@@ -69,6 +70,8 @@ public class RpcServiceHttp2SecurityTest {
   private CommonParameter parameter;
   private int previousRpcThreadNum;
   private int previousMaxConcurrentCalls;
+  private int previousMaxConnections;
+  private int previousMaxConnectionsPerIp;
   private int previousFlowControlWindow;
   private long previousMaxConnectionIdle;
   private long previousMaxConnectionAge;
@@ -83,6 +86,8 @@ public class RpcServiceHttp2SecurityTest {
     parameter = Args.getInstance();
     previousRpcThreadNum = parameter.getRpcThreadNum();
     previousMaxConcurrentCalls = parameter.getMaxConcurrentCallsPerConnection();
+    previousMaxConnections = parameter.getRpcMaxConnections();
+    previousMaxConnectionsPerIp = parameter.getRpcMaxConnectionsPerIp();
     previousFlowControlWindow = parameter.getFlowControlWindow();
     previousMaxConnectionIdle = parameter.getMaxConnectionIdleInMillis();
     previousMaxConnectionAge = parameter.getMaxConnectionAgeInMillis();
@@ -94,6 +99,8 @@ public class RpcServiceHttp2SecurityTest {
 
     parameter.setRpcThreadNum(0);
     parameter.setMaxConcurrentCallsPerConnection(2);
+    parameter.setRpcMaxConnections(512);
+    parameter.setRpcMaxConnectionsPerIp(32);
     parameter.setFlowControlWindow(NettyServerBuilder.DEFAULT_FLOW_CONTROL_WINDOW);
     parameter.setMaxConnectionIdleInMillis(60_000);
     parameter.setMaxConnectionAgeInMillis(Long.MAX_VALUE);
@@ -108,6 +115,8 @@ public class RpcServiceHttp2SecurityTest {
   public void tearDown() {
     parameter.setRpcThreadNum(previousRpcThreadNum);
     parameter.setMaxConcurrentCallsPerConnection(previousMaxConcurrentCalls);
+    parameter.setRpcMaxConnections(previousMaxConnections);
+    parameter.setRpcMaxConnectionsPerIp(previousMaxConnectionsPerIp);
     parameter.setFlowControlWindow(previousFlowControlWindow);
     parameter.setMaxConnectionIdleInMillis(previousMaxConnectionIdle);
     parameter.setMaxConnectionAgeInMillis(previousMaxConnectionAge);
@@ -141,6 +150,121 @@ public class RpcServiceHttp2SecurityTest {
       server.shutdownNow();
       assertTrue(server.awaitTermination(5, TimeUnit.SECONDS));
     }
+  }
+
+  @Test
+  public void shouldRejectExcessConnectionsAndReleasePermitAfterClose() throws Exception {
+    parameter.setRpcMaxConnections(2);
+    parameter.setRpcMaxConnectionsPerIp(1);
+    TestRpcService rpcService = new TestRpcService();
+    Server server = rpcService.newServerBuilder()
+        .addService(newHoldService())
+        .build()
+        .start();
+
+    try {
+      try (Socket first = openHttp2Connection(server.getPort())) {
+        awaitActiveConnections(rpcService.connectionLimiter, 1);
+        try (Socket rejected = new Socket("127.0.0.1", server.getPort())) {
+          rejected.setSoTimeout(5_000);
+          assertConnectionClosed(rejected);
+        }
+        assertEquals(1, rpcService.connectionLimiter.activeConnections());
+      }
+
+      awaitActiveConnections(rpcService.connectionLimiter, 0);
+      try (Socket replacement = openHttp2Connection(server.getPort())) {
+        awaitActiveConnections(rpcService.connectionLimiter, 1);
+      }
+      awaitActiveConnections(rpcService.connectionLimiter, 0);
+    } finally {
+      server.shutdownNow();
+      assertTrue(server.awaitTermination(5, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  public void shouldShareConnectionLimitAcrossRpcServers() throws Exception {
+    parameter.setRpcMaxConnections(1);
+    parameter.setRpcMaxConnectionsPerIp(1);
+    GrpcConnectionLimiter sharedLimiter = new GrpcConnectionLimiter();
+    TestRpcService firstRpcService = new TestRpcService(sharedLimiter);
+    TestRpcService secondRpcService = new TestRpcService(sharedLimiter);
+    Server firstServer = firstRpcService.newServerBuilder()
+        .addService(newHoldService())
+        .build()
+        .start();
+    Server secondServer = secondRpcService.newServerBuilder()
+        .addService(newHoldService())
+        .build()
+        .start();
+
+    try {
+      try (Socket first = openHttp2Connection(firstServer.getPort())) {
+        awaitActiveConnections(sharedLimiter, 1);
+        try (Socket rejected = new Socket("127.0.0.1", secondServer.getPort())) {
+          rejected.setSoTimeout(5_000);
+          assertConnectionClosed(rejected);
+        }
+      }
+
+      awaitActiveConnections(sharedLimiter, 0);
+      try (Socket replacement = openHttp2Connection(secondServer.getPort())) {
+        awaitActiveConnections(sharedLimiter, 1);
+      }
+      awaitActiveConnections(sharedLimiter, 0);
+    } finally {
+      firstServer.shutdownNow();
+      secondServer.shutdownNow();
+      assertTrue(firstServer.awaitTermination(5, TimeUnit.SECONDS));
+      assertTrue(secondServer.awaitTermination(5, TimeUnit.SECONDS));
+    }
+  }
+
+  private static Socket openHttp2Connection(int port) throws IOException {
+    Socket socket = new Socket("127.0.0.1", port);
+    try {
+      socket.setSoTimeout(5_000);
+      OutputStream output = socket.getOutputStream();
+      output.write(CLIENT_PREFACE);
+      output.write(EMPTY_SETTINGS_FRAME);
+      output.flush();
+      assertServerSettings(socket.getInputStream());
+      return socket;
+    } catch (IOException | RuntimeException | Error e) {
+      socket.close();
+      throw e;
+    }
+  }
+
+  private static void assertServerSettings(InputStream input) throws IOException {
+    for (int i = 0; i < 10; i++) {
+      Http2Frame frame = readFrame(input);
+      if (frame.type == SETTINGS_FRAME_TYPE && frame.streamId == 0) {
+        return;
+      }
+    }
+    fail("Server did not send HTTP/2 SETTINGS");
+  }
+
+  private static void assertConnectionClosed(Socket socket) throws IOException {
+    try {
+      assertEquals(-1, socket.getInputStream().read());
+    } catch (SocketException expected) {
+      // A TCP reset is also a valid immediate rejection.
+    }
+  }
+
+  private static void awaitActiveConnections(
+      GrpcConnectionLimiter limiter, int expectedConnections) throws InterruptedException {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+    while (System.nanoTime() < deadline) {
+      if (limiter.activeConnections() == expectedConnections) {
+        return;
+      }
+      Thread.sleep(10);
+    }
+    assertEquals(expectedConnections, limiter.activeConnections());
   }
 
   private static ServerServiceDefinition newHoldService() {
@@ -268,12 +392,24 @@ public class RpcServiceHttp2SecurityTest {
 
   private static final class TestRpcService extends RpcService {
 
+    private final GrpcConnectionLimiter connectionLimiter;
+
     private TestRpcService() {
+      this(new GrpcConnectionLimiter());
+    }
+
+    private TestRpcService(GrpcConnectionLimiter connectionLimiter) {
+      this.connectionLimiter = connectionLimiter;
       port = 0;
     }
 
     private NettyServerBuilder newServerBuilder() {
       return initServerBuilder();
+    }
+
+    @Override
+    GrpcConnectionLimiter connectionLimiter() {
+      return connectionLimiter;
     }
 
     @Override

--- a/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
+++ b/framework/src/test/java/org/tron/core/config/args/ArgsTest.java
@@ -104,6 +104,8 @@ public class ArgsTest {
     // gRPC network configs checking
     Assert.assertEquals(50051, parameter.getRpcPort());
     Assert.assertEquals(100, parameter.getMaxConcurrentCallsPerConnection());
+    Assert.assertEquals(512, parameter.getRpcMaxConnections());
+    Assert.assertEquals(32, parameter.getRpcMaxConnectionsPerIp());
     Assert
         .assertEquals(NettyServerBuilder
             .DEFAULT_FLOW_CONTROL_WINDOW, parameter.getFlowControlWindow());

--- a/framework/src/test/java/org/tron/core/services/http/JsonFormatTest.java
+++ b/framework/src/test/java/org/tron/core/services/http/JsonFormatTest.java
@@ -6,23 +6,25 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnknownFieldSet;
-
 import java.io.CharArrayReader;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.tron.core.Constant;
 import org.tron.protos.Protocol;
+import org.tron.protos.contract.AccountContract.AccountUpdateContract;
 import org.tron.protos.contract.ProposalContract.ProposalCreateContract;
 import org.tron.protos.contract.SmartContractOuterClass.CreateSmartContract;
 import org.tron.protos.contract.SmartContractOuterClass.SmartContract.ABI.Entry;
+import org.tron.protos.contract.WitnessContract.WitnessCreateContract;
 
 public class JsonFormatTest {
   @After
@@ -132,6 +134,42 @@ public class JsonFormatTest {
     String input1 = "\b\f\n\r\t\\\"\\b\\f\\n\\r\\t\\\\\"test123";
     String out = (String)privateMethod.invoke(null, input1);
     assertNotNull(out);
+  }
+
+  @Test
+  public void testSelfTypeEscapesNameAndUrlBytesAsStrictJson() throws IOException {
+    String value = "line1\nline2\r\t\b\f\u0000tail";
+    ObjectMapper strictMapper = new ObjectMapper();
+
+    AccountUpdateContract accountUpdate = AccountUpdateContract.newBuilder()
+        .setAccountName(ByteString.copyFromUtf8(value))
+        .build();
+    JsonNode accountJson = strictMapper.readTree(JsonFormat.printToString(accountUpdate, true));
+    assertEquals(value, accountJson.get("account_name").textValue());
+
+    WitnessCreateContract witnessCreate = WitnessCreateContract.newBuilder()
+        .setUrl(ByteString.copyFromUtf8(value))
+        .build();
+    JsonNode witnessJson = strictMapper.readTree(JsonFormat.printToString(witnessCreate, true));
+    assertEquals(value, witnessJson.get("url").textValue());
+  }
+
+  @Test
+  public void testSelfTypeEscapesBackslashAndQuote() throws IOException {
+    String value = "slash\\quote\"tail";
+    String escaped = JsonFormat.escapeBytesSelfType(
+        ByteString.copyFromUtf8(value), "protocol.AccountUpdateContract.account_name");
+    JsonNode json = new ObjectMapper().readTree("{\"value\":\"" + escaped + "\"}");
+
+    assertEquals(value, json.get("value").textValue());
+  }
+
+  @Test
+  public void testSelfTypeNameFallsBackToHexForInvalidUtf8() {
+    ByteString invalidUtf8 = ByteString.copyFrom(new byte[]{(byte) 0xc3, 0x28});
+
+    assertEquals("c328", JsonFormat.escapeBytesSelfType(
+        invalidUtf8, "protocol.AccountUpdateContract.account_name"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- add a JVM-wide active gRPC connection limiter shared by the FullNode, Solidity, and PBFT RPC ports
- enforce both a global connection cap and a per-source-IP cap before HTTP/2 request processing
- release permits from the Netty channel close future, including idempotent release handling
- add validated configuration with secure defaults (`maxConnections = 512`, `maxConnectionsPerIp = 32`)
- document multi-port behavior and the reverse-proxy source-address caveat

## Security rationale

The existing HTTP/2 stream cap limits concurrent streams on one connection, but it does not bound an attacker opening many connections and a small number of streams on each. That pattern can consume the process file-descriptor budget when `ulimit -n` is low.

This change adds application-level admission control as defense in depth:

- the global cap bounds active gRPC sockets across all three RPC servers, instead of applying a separate budget to every port
- the per-IP cap prevents one directly connected source from consuming the whole global budget
- an over-limit connection is closed before the delegated gRPC/HTTP2 handler is installed
- closing an admitted channel immediately returns both global and per-IP capacity

## Configuration

```hocon
node.rpc.maxConnections = 512
node.rpc.maxConnectionsPerIp = 32
```

Both values must be non-negative, and the per-IP limit must not exceed the global limit. A value of `0` selects the secure default rather than disabling the protection. Operators behind a reverse proxy should enforce the client-IP limit at the proxy, because java-tron sees the proxy source address unless the original source address is preserved at the network layer.

## Validation

Passed:

- `:common:compileJava`, `:framework:compileJava`, and `:framework:compileTestJava`
- `NodeConfigTest`, including defaults, zero fallback, invalid values, and explicit overrides
- `GrpcConnectionLimiterTest`, including global/per-IP limits, idempotent release, replacement admission, and 64-way concurrent admission against a cap of 8
- `GrpcNettyMaxConcurrentStreamsLimiterTest`
- `RpcServiceHttp2SecurityTest`, including real TCP/HTTP2 connections, immediate rejection, permit release, replacement admission, and one shared limit across two live RPC servers
- `ArgsTest`
- `JsonFormatTest`, including strict-JSON round trips for chain-controlled name/URL control characters, backslash/quote escaping, and invalid UTF-8 fallback
- `:framework:checkstyleMain` and `:framework:checkstyleTest`
- `git diff --check`

A full `:common:test :framework:test` sweep was also started. It reached the large RocksDB/Spring integration-test section, but the host temporary volume became full and RocksDB began failing with `No space left on device`, so the sweep was stopped. Before disk exhaustion, the failures reported were in unchanged Jetty/VM tests (`SizeLimitHandlerTest`, `AllowTvmLondonTest`, and `ValidateMultiSignContractTest`); none of the changed gRPC/configuration tests failed.

An expanded `org.tron.core.services.http.*` sweep was attempted after the JSON review fix. It passed the serializer tests and many servlet tests, but the same nearly-full host volume eventually prevented Gradle and RocksDB from writing test results. The focused `JsonFormatTest` suite was then rerun independently and passed in full.

## Review follow-up: HTTP JSON byte-field escaping

The self-type HTTP formatter previously escaped only double quotes for name-like bytes fields and then validated the result with a deliberately permissive JSON parser. Raw control characters could therefore reach HTTP JSON responses, while invalid UTF-8 was decoded with the platform default replacement behavior.

The follow-up commit now:

- validates UTF-8 before rendering chain-controlled name, URL, and description bytes as text
- applies the existing complete JSON string escaping for control characters, backslashes, and quotes
- falls back to the original hexadecimal representation for invalid UTF-8
- removes the permissive parse-as-validation path

## Scope and operational note

This is application-level connection admission, not a replacement for OS and edge controls. A TCP socket is necessarily accepted before the child channel can be rejected, so connection-rate floods should still be handled with an appropriate `ulimit`, firewall/load-balancer connection limits, backlog tuning, and monitoring.
