### PR TITLE
fix(net): harden shared state concurrency

### DIFF
--- a/framework/src/main/java/org/tron/common/backup/BackupManager.java
+++ b/framework/src/main/java/org/tron/common/backup/BackupManager.java
@@ -58,7 +58,7 @@ public class BackupManager implements EventHandler {
   private MessageHandler messageHandler;
 
   @Getter
-  private BackupStatusEnum status = MASTER;
+  private volatile BackupStatusEnum status = MASTER;
 
   private volatile long lastKeepAliveTime;
 

--- a/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
+++ b/framework/src/main/java/org/tron/core/metrics/blockchain/BlockChainMetricManager.java
@@ -138,10 +138,10 @@ public class BlockChainMetricManager {
       BlockCapsule oldBlock = witnessInfo.get(witnessAddress);
       if ((!oldBlock.getBlockId().equals(block.getBlockId()))
           && oldBlock.getTimeStamp() == block.getTimeStamp()) {
+        dupWitnessBlockNum.put(witnessAddress, block.getNum());
         MetricsUtil.counterInc(MetricsKey.BLOCKCHAIN_DUP_WITNESS + witnessAddress);
         Metrics.counterInc(MetricKeys.Counter.MINER, 1,
             StringUtil.encode58Check(address), MetricLabels.Counter.MINE_DUP);
-        dupWitnessBlockNum.put(witnessAddress, block.getNum());
       }
     }
     witnessInfo.put(witnessAddress, block);
@@ -204,7 +204,7 @@ public class BlockChainMetricManager {
     for (Map.Entry<String, Counter> entry : dupWitnessMap.entrySet()) {
       DupWitnessInfo dupWitness = new DupWitnessInfo();
       String witness = entry.getKey().substring(MetricsKey.BLOCKCHAIN_DUP_WITNESS.length());
-      long blockNum = dupWitnessBlockNum.get(witness);
+      long blockNum = dupWitnessBlockNum.getOrDefault(witness, 0L);
       dupWitness.setAddress(witness);
       dupWitness.setBlockNum(blockNum);
       dupWitness.setCount((int) entry.getValue().getCount());

--- a/framework/src/main/java/org/tron/core/net/messagehandler/ChainInventoryMsgHandler.java
+++ b/framework/src/main/java/org/tron/core/net/messagehandler/ChainInventoryMsgHandler.java
@@ -86,15 +86,15 @@ public class ChainInventoryMsgHandler implements TronMsgHandler {
         peer.setFetchAble(true);
         return;
       }
-    }
 
-    peer.setFetchAble(true);
-    if ((chainInventoryMessage.getRemainNum() == 0 && !peer.getSyncBlockToFetch().isEmpty())
-        || (chainInventoryMessage.getRemainNum() != 0
-        && peer.getSyncBlockToFetch().size() > syncFetchBatchNum)) {
-      syncService.setFetchFlag(true);
-    } else {
-      syncService.syncNext(peer);
+      peer.setFetchAble(true);
+      if ((chainInventoryMessage.getRemainNum() == 0 && !peer.getSyncBlockToFetch().isEmpty())
+          || (chainInventoryMessage.getRemainNum() != 0
+          && peer.getSyncBlockToFetch().size() > syncFetchBatchNum)) {
+        syncService.setFetchFlag(true);
+      } else {
+        syncService.syncNext(peer);
+      }
     }
   }
 

--- a/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerConnection.java
@@ -10,7 +10,6 @@ import com.google.protobuf.ByteString;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Deque;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -158,7 +157,7 @@ public class PeerConnection {
   private volatile Pair<Deque<BlockId>, Long> syncChainRequested = null;
   @Setter
   @Getter
-  private Set<BlockId> syncBlockInProcess = new HashSet<>();
+  private Set<BlockId> syncBlockInProcess = ConcurrentHashMap.newKeySet();
   @Setter
   @Getter
   private volatile boolean needSyncFromPeer = true;

--- a/framework/src/main/java/org/tron/core/net/peer/PeerManager.java
+++ b/framework/src/main/java/org/tron/core/net/peer/PeerManager.java
@@ -120,7 +120,7 @@ public class PeerManager {
     return peers;
   }
 
-  private static void check() {
+  private static synchronized void check() {
     long now = System.currentTimeMillis();
     for (PeerConnection peer : new ArrayList<>(peers)) {
       long disconnectTime = peer.getChannel().getDisconnectTime();

--- a/framework/src/main/java/org/tron/core/net/service/fetchblock/FetchBlockService.java
+++ b/framework/src/main/java/org/tron/core/net/service/fetchblock/FetchBlockService.java
@@ -34,7 +34,7 @@ public class FetchBlockService {
   @Autowired
   private ChainBaseManager chainBaseManager;
 
-  private FetchBlockInfo fetchBlockInfo = null;
+  private volatile FetchBlockInfo fetchBlockInfo = null;
 
   private final long fetchTimeOut = CommonParameter.getInstance().fetchBlockTimeout;
 

--- a/framework/src/main/java/org/tron/core/net/service/statistics/MessageCount.java
+++ b/framework/src/main/java/org/tron/core/net/service/statistics/MessageCount.java
@@ -15,7 +15,7 @@ public class MessageCount {
 
   private long totalCount = 0;
 
-  private void update() {
+  private synchronized void update() {
     long time = System.currentTimeMillis() / 1000;
     long gap = time - indexTime;
     int k = gap > SIZE ? SIZE : (int) gap;
@@ -28,19 +28,19 @@ public class MessageCount {
     }
   }
 
-  public void add() {
+  public synchronized void add() {
     update();
     szCount[index]++;
     totalCount++;
   }
 
-  public void add(int count) {
+  public synchronized void add(int count) {
     update();
     szCount[index] += count;
     totalCount += count;
   }
 
-  public int getCount(int interval) {
+  public synchronized int getCount(int interval) {
     if (interval > SIZE) {
       logger.warn("Param interval({}) is gt SIZE({})", interval, SIZE);
       return 0;
@@ -53,16 +53,16 @@ public class MessageCount {
     return count;
   }
 
-  public long getTotalCount() {
+  public synchronized long getTotalCount() {
     return totalCount;
   }
 
-  public void reset() {
+  public synchronized void reset() {
     totalCount = 0;
   }
 
   @Override
-  public String toString() {
+  public synchronized String toString() {
     return String.valueOf(totalCount);
   }
 

--- a/framework/src/main/java/org/tron/core/services/WitnessProductBlockService.java
+++ b/framework/src/main/java/org/tron/core/services/WitnessProductBlockService.java
@@ -3,10 +3,10 @@ package org.tron.core.services;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,7 +20,7 @@ public class WitnessProductBlockService {
   private Cache<Long, BlockCapsule> historyBlockCapsuleCache = CacheBuilder.newBuilder()
       .initialCapacity(200).maximumSize(200).build();
 
-  private Map<String, CheatWitnessInfo> cheatWitnessInfoMap = new HashMap<>();
+  private Map<String, CheatWitnessInfo> cheatWitnessInfoMap = new ConcurrentHashMap<>();
 
   public void validWitnessProductTwoBlock(BlockCapsule block) {
     try {

--- a/framework/src/test/java/org/tron/common/backup/BackupManagerTest.java
+++ b/framework/src/test/java/org/tron/common/backup/BackupManagerTest.java
@@ -2,6 +2,7 @@ package org.tron.common.backup;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -50,6 +51,13 @@ public class BackupManagerTest {
   public void tearDown() {
     InetUtil.dnsLookup = savedLookup;
     Args.clearParam();
+  }
+
+  @Test
+  public void statusIsVolatileForCrossThreadVisibility() throws Exception {
+    Field status = BackupManager.class.getDeclaredField("status");
+
+    Assert.assertTrue(Modifier.isVolatile(status.getModifiers()));
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/metrics/blockchain/BlockChainMetricManagerTest.java
+++ b/framework/src/test/java/org/tron/core/metrics/blockchain/BlockChainMetricManagerTest.java
@@ -1,0 +1,38 @@
+package org.tron.core.metrics.blockchain;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.tron.common.parameter.CommonParameter;
+import org.tron.core.metrics.MetricsKey;
+import org.tron.core.metrics.MetricsUtil;
+
+public class BlockChainMetricManagerTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void missingDuplicateWitnessBlockNumberDefaultsToZero() throws Exception {
+    CommonParameter parameter = CommonParameter.getInstance();
+    boolean nodeMetricsEnabled = parameter.isNodeMetricsEnable();
+    String witness = "missing-block-number-" + System.nanoTime();
+    parameter.setNodeMetricsEnable(true);
+    try {
+      MetricsUtil.counterInc(MetricsKey.BLOCKCHAIN_DUP_WITNESS + witness);
+
+      Method getDupWitness = BlockChainMetricManager.class.getDeclaredMethod("getDupWitness");
+      getDupWitness.setAccessible(true);
+      List<DupWitnessInfo> dupWitnesses = (List<DupWitnessInfo>) getDupWitness.invoke(
+          new BlockChainMetricManager());
+
+      DupWitnessInfo dupWitness = dupWitnesses.stream()
+          .filter(info -> witness.equals(info.getAddress()))
+          .findFirst()
+          .orElse(null);
+      Assert.assertNotNull(dupWitness);
+      Assert.assertEquals(0L, dupWitness.getBlockNum());
+    } finally {
+      parameter.setNodeMetricsEnable(nodeMetricsEnabled);
+    }
+  }
+}

--- a/framework/src/test/java/org/tron/core/net/messagehandler/ChainInventoryMsgHandlerTest.java
+++ b/framework/src/test/java/org/tron/core/net/messagehandler/ChainInventoryMsgHandlerTest.java
@@ -1,21 +1,28 @@
 package org.tron.core.net.messagehandler;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.tron.common.TestConstants;
 import org.tron.common.utils.Pair;
+import org.tron.common.utils.ReflectUtils;
+import org.tron.common.utils.Sha256Hash;
 import org.tron.core.capsule.BlockCapsule.BlockId;
 import org.tron.core.config.Parameter.NetConstants;
 import org.tron.core.config.args.Args;
 import org.tron.core.exception.P2pException;
+import org.tron.core.net.TronNetDelegate;
 import org.tron.core.net.message.keepalive.PingMessage;
 import org.tron.core.net.message.sync.ChainInventoryMessage;
 import org.tron.core.net.peer.PeerConnection;
+import org.tron.core.net.service.sync.SyncService;
 
 public class ChainInventoryMsgHandlerTest {
 
@@ -76,6 +83,76 @@ public class ChainInventoryMsgHandlerTest {
     }
     Assert.assertNotNull(msg.toString());
     Assert.assertNull(msg.getAnswerMessage());
+  }
+
+  @Test
+  public void testFetchFlagDecisionIsMadeUnderBlockLock() throws Exception {
+    Object blockLock = new Object();
+    TronNetDelegate tronNetDelegate = Mockito.mock(TronNetDelegate.class);
+    SyncService syncService = Mockito.mock(SyncService.class);
+    PeerConnection testPeer = Mockito.spy(new PeerConnection());
+    AtomicBoolean fetchAbleSetUnderLock = new AtomicBoolean();
+    AtomicBoolean fetchFlagSetUnderLock = new AtomicBoolean();
+    BlockId firstBlock = new BlockId(Sha256Hash.ZERO_HASH, 1);
+    BlockId secondBlock = new BlockId(Sha256Hash.ZERO_HASH, 2);
+
+    Mockito.when(tronNetDelegate.getBlockLock()).thenReturn(blockLock);
+    Mockito.when(tronNetDelegate.getHeadBlockId()).thenReturn(new BlockId(Sha256Hash.ZERO_HASH, 0));
+    Mockito.when(tronNetDelegate.containBlock(Mockito.any())).thenReturn(false);
+    Mockito.doAnswer(invocation -> {
+      if (invocation.getArgument(0)) {
+        fetchAbleSetUnderLock.set(Thread.holdsLock(blockLock));
+      }
+      return invocation.callRealMethod();
+    }).when(testPeer).setFetchAble(Mockito.anyBoolean());
+    Mockito.doAnswer(invocation -> {
+      fetchFlagSetUnderLock.set(Thread.holdsLock(blockLock));
+      return null;
+    }).when(syncService).setFetchFlag(true);
+    ReflectUtils.setFieldValue(handler, "tronNetDelegate", tronNetDelegate);
+    ReflectUtils.setFieldValue(handler, "syncService", syncService);
+    testPeer.setSyncChainRequested(new Pair<>(new LinkedList<>(Arrays.asList(firstBlock)),
+        System.currentTimeMillis()));
+
+    handler.processMessage(testPeer,
+        new ChainInventoryMessage(Arrays.asList(firstBlock, secondBlock), 0L));
+
+    Assert.assertTrue(fetchAbleSetUnderLock.get());
+    Assert.assertTrue(fetchFlagSetUnderLock.get());
+  }
+
+  @Test
+  public void testSyncNextDecisionIsMadeUnderBlockLock() throws Exception {
+    Object blockLock = new Object();
+    TronNetDelegate tronNetDelegate = Mockito.mock(TronNetDelegate.class);
+    SyncService syncService = Mockito.mock(SyncService.class);
+    PeerConnection testPeer = Mockito.spy(new PeerConnection());
+    AtomicBoolean fetchAbleSetUnderLock = new AtomicBoolean();
+    AtomicBoolean syncNextCalledUnderLock = new AtomicBoolean();
+    BlockId firstBlock = new BlockId(Sha256Hash.ZERO_HASH, 1);
+
+    Mockito.when(tronNetDelegate.getBlockLock()).thenReturn(blockLock);
+    Mockito.when(tronNetDelegate.getHeadBlockId()).thenReturn(new BlockId(Sha256Hash.ZERO_HASH, 0));
+    Mockito.when(tronNetDelegate.containBlock(Mockito.any())).thenReturn(false);
+    Mockito.doAnswer(invocation -> {
+      if (invocation.getArgument(0)) {
+        fetchAbleSetUnderLock.set(Thread.holdsLock(blockLock));
+      }
+      return invocation.callRealMethod();
+    }).when(testPeer).setFetchAble(Mockito.anyBoolean());
+    Mockito.doAnswer(invocation -> {
+      syncNextCalledUnderLock.set(Thread.holdsLock(blockLock));
+      return null;
+    }).when(syncService).syncNext(testPeer);
+    ReflectUtils.setFieldValue(handler, "tronNetDelegate", tronNetDelegate);
+    ReflectUtils.setFieldValue(handler, "syncService", syncService);
+    testPeer.setSyncChainRequested(new Pair<>(new LinkedList<>(Arrays.asList(firstBlock)),
+        System.currentTimeMillis()));
+
+    handler.processMessage(testPeer, new ChainInventoryMessage(Arrays.asList(firstBlock), 0L));
+
+    Assert.assertTrue(fetchAbleSetUnderLock.get());
+    Assert.assertTrue(syncNextCalledUnderLock.get());
   }
 
 }

--- a/framework/src/test/java/org/tron/core/net/peer/PeerConnectionTest.java
+++ b/framework/src/test/java/org/tron/core/net/peer/PeerConnectionTest.java
@@ -6,6 +6,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -54,6 +55,14 @@ public class PeerConnectionTest {
     Assert.assertTrue(peerConnection.isNeedSyncFromPeer());
     Assert.assertTrue(peerConnection.isNeedSyncFromUs());
     Assert.assertTrue(!peerConnection.isSyncFinish());
+  }
+
+  @Test
+  public void testSyncBlockInProcessUsesConcurrentSet() {
+    PeerConnection peerConnection = new PeerConnection();
+
+    Assert.assertTrue(peerConnection.getSyncBlockInProcess()
+        instanceof ConcurrentHashMap.KeySetView);
   }
 
   @Test

--- a/framework/src/test/java/org/tron/core/net/peer/PeerManagerTest.java
+++ b/framework/src/test/java/org/tron/core/net/peer/PeerManagerTest.java
@@ -3,10 +3,16 @@ package org.tron.core.net.peer;
 import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -186,6 +192,66 @@ public class PeerManagerTest {
     PeerManager.sortPeers();
 
     Assert.assertEquals(PeerManager.getPeers().get(0), p2);
+  }
+
+  @Test(timeout = 5_000)
+  public void checkAndRemoveAreSerialized() throws Exception {
+    CountDownLatch checkReachedPeer = new CountDownLatch(1);
+    CountDownLatch continueCheck = new CountDownLatch(1);
+    CountDownLatch removeFinished = new CountDownLatch(1);
+    Channel channel = mock(Channel.class);
+    PeerConnection peer = mock(PeerConnection.class);
+    Mockito.when(peer.getChannel()).thenReturn(channel);
+    Mockito.when(channel.isActive()).thenReturn(true);
+    Mockito.when(channel.getDisconnectTime()).thenAnswer(invocation -> {
+      checkReachedPeer.countDown();
+      continueCheck.await();
+      return System.currentTimeMillis() - 120_000;
+    });
+
+    Field peersField = PeerManager.class.getDeclaredField("peers");
+    peersField.setAccessible(true);
+    peersField.set(null, Collections.synchronizedList(
+        new ArrayList<>(Collections.singletonList(peer))));
+    PeerManager.getActivePeersCount().set(1);
+    PeerManager.getPassivePeersCount().set(0);
+
+    Method check = PeerManager.class.getDeclaredMethod("check");
+    check.setAccessible(true);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> checkFuture = executor.submit(() -> {
+        try {
+          check.invoke(null);
+        } catch (ReflectiveOperationException e) {
+          throw new RuntimeException(e);
+        }
+      });
+      Assert.assertTrue(checkReachedPeer.await(1, TimeUnit.SECONDS));
+
+      Future<PeerConnection> removeFuture = executor.submit(() -> {
+        try {
+          return PeerManager.remove(channel);
+        } finally {
+          removeFinished.countDown();
+        }
+      });
+
+      boolean removedWhileCheckPaused = removeFinished.await(300, TimeUnit.MILLISECONDS);
+      continueCheck.countDown();
+      checkFuture.get(1, TimeUnit.SECONDS);
+
+      Assert.assertFalse(removedWhileCheckPaused);
+      Assert.assertNull(removeFuture.get(1, TimeUnit.SECONDS));
+      Assert.assertEquals(0, PeerManager.getActivePeersCount().get());
+    } finally {
+      continueCheck.countDown();
+      executor.shutdownNow();
+      Assert.assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+      peersField.set(null, Collections.synchronizedList(new ArrayList<>()));
+      PeerManager.getActivePeersCount().set(0);
+      PeerManager.getPassivePeersCount().set(0);
+    }
   }
 
 }

--- a/framework/src/test/java/org/tron/core/net/service/fetchblock/FetchBlockServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/service/fetchblock/FetchBlockServiceTest.java
@@ -1,0 +1,16 @@
+package org.tron.core.net.service.fetchblock;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FetchBlockServiceTest {
+
+  @Test
+  public void testFetchBlockInfoIsVolatile() throws Exception {
+    Field fetchBlockInfo = FetchBlockService.class.getDeclaredField("fetchBlockInfo");
+
+    Assert.assertTrue(Modifier.isVolatile(fetchBlockInfo.getModifiers()));
+  }
+}

--- a/framework/src/test/java/org/tron/core/net/service/statistics/MessageCountTest.java
+++ b/framework/src/test/java/org/tron/core/net/service/statistics/MessageCountTest.java
@@ -1,0 +1,114 @@
+package org.tron.core.net.service.statistics;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MessageCountTest {
+
+  private static final int THREAD_COUNT = 8;
+  private static final int ITERATIONS = 50_000;
+
+  @Test(timeout = 10_000)
+  public void windowOperationsUseOneMonitor() throws Exception {
+    MessageCount messageCount = new MessageCount();
+    Method update = MessageCount.class.getDeclaredMethod("update");
+    update.setAccessible(true);
+    List<CheckedRunnable> operations = Arrays.asList(
+        messageCount::add,
+        () -> messageCount.add(2),
+        () -> messageCount.getCount(1),
+        messageCount::getTotalCount,
+        messageCount::reset,
+        messageCount::toString,
+        () -> update.invoke(messageCount));
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      for (CheckedRunnable operation : operations) {
+        assertUsesMonitor(messageCount, executor, operation);
+      }
+    } finally {
+      executor.shutdownNow();
+      Assert.assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test(timeout = 10_000)
+  public void concurrentAddsDoNotLoseUpdates() throws Exception {
+    MessageCount messageCount = new MessageCount();
+    ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    CountDownLatch ready = new CountDownLatch(THREAD_COUNT);
+    CountDownLatch start = new CountDownLatch(1);
+    try {
+      Future<?>[] futures = new Future<?>[THREAD_COUNT];
+      for (int thread = 0; thread < THREAD_COUNT; thread++) {
+        futures[thread] = executor.submit(() -> {
+          ready.countDown();
+          try {
+            start.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+          }
+          for (int i = 0; i < ITERATIONS; i++) {
+            if ((i & 1) == 0) {
+              messageCount.add();
+            } else {
+              messageCount.add(2);
+            }
+          }
+        });
+      }
+
+      Assert.assertTrue(ready.await(1, TimeUnit.SECONDS));
+      start.countDown();
+      for (Future<?> future : futures) {
+        future.get(5, TimeUnit.SECONDS);
+      }
+
+      int expected = THREAD_COUNT * ITERATIONS / 2 * 3;
+      Assert.assertEquals(expected, messageCount.getTotalCount());
+      Assert.assertEquals(expected, messageCount.getCount(60));
+    } finally {
+      start.countDown();
+      executor.shutdownNow();
+      Assert.assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+    }
+  }
+
+  private void assertUsesMonitor(MessageCount messageCount, ExecutorService executor,
+      CheckedRunnable operation) throws Exception {
+    CountDownLatch started = new CountDownLatch(1);
+    CountDownLatch finished = new CountDownLatch(1);
+    Future<?> future;
+    synchronized (messageCount) {
+      future = executor.submit(() -> {
+        started.countDown();
+        try {
+          operation.run();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        } finally {
+          finished.countDown();
+        }
+      });
+      Assert.assertTrue(started.await(1, TimeUnit.SECONDS));
+      Assert.assertFalse(finished.await(100, TimeUnit.MILLISECONDS));
+    }
+    future.get(1, TimeUnit.SECONDS);
+  }
+
+  @FunctionalInterface
+  private interface CheckedRunnable {
+
+    void run() throws Exception;
+  }
+}

--- a/framework/src/test/java/org/tron/core/services/WitnessProductBlockServiceTest.java
+++ b/framework/src/test/java/org/tron/core/services/WitnessProductBlockServiceTest.java
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
@@ -12,6 +13,14 @@ import org.tron.common.utils.Sha256Hash;
 import org.tron.core.capsule.BlockCapsule;
 
 public class WitnessProductBlockServiceTest {
+
+  @Test
+  public void cheatWitnessInfoMapSupportsConcurrentUpdates() {
+    WitnessProductBlockService witnessProductBlockService = new WitnessProductBlockService();
+
+    Assert.assertTrue(witnessProductBlockService.queryCheatWitnessInfo()
+        instanceof ConcurrentHashMap);
+  }
 
   @Test
   public void GetSetCheatWitnessInfoTest() {


### PR DESCRIPTION
Network workers, synchronization tasks, metrics collectors, and backup services access several mutable states across threads without consistent visibility or synchronization guarantees.

Use concurrent collections and synchronized state transitions where compound access must remain atomic, publish cross-thread fields safely, serialize peer cleanup with existing manager operations, and prevent duplicate-witness metrics from exposing incomplete companion state.

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

