### PR TITLE
fix(net): prevent hello message replay

### DIFF
--- a/common/src/main/java/org/tron/common/parameter/CommonParameter.java
+++ b/common/src/main/java/org/tron/common/parameter/CommonParameter.java
@@ -322,6 +322,9 @@ public class CommonParameter {
   public int inactiveThreshold = 600; // from clearParam(), consistent with mainnet.conf
   @Getter
   @Setter
+  public int helloMsgTimestampThreshold = 1800;
+  @Getter
+  @Setter
   public boolean nodeDetectEnable;
   @Getter
   @Setter

--- a/common/src/main/java/org/tron/core/config/args/NodeConfig.java
+++ b/common/src/main/java/org/tron/core/config/args/NodeConfig.java
@@ -188,6 +188,7 @@ public class NodeConfig {
   public static class P2pConfig {
 
     private int version = 11111;
+    private int helloMsgTimestampThreshold = 1800;
   }
 
   @Getter
@@ -356,6 +357,8 @@ public class NodeConfig {
    * Runs after ConfigBeanFactory binding and manual field reads.
    */
   private void postProcess() {
+    p2p.helloMsgTimestampThreshold = Math.max(1, p2p.helloMsgTimestampThreshold);
+
     // rpcThreadNum: 0 = auto-detect
     if (rpc.thread == 0) {
       rpc.thread = (Runtime.getRuntime().availableProcessors() + 1) / 2;

--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -241,6 +241,7 @@ node {
   # P2P protocol version settings.
   p2p {
     version = 11111   # Mainnet:11111; Nile:201910292; Shasta:1
+    helloMsgTimestampThreshold = 1800  # seconds
   }
 
   # Peers to actively connect to.

--- a/framework/src/main/java/org/tron/core/config/args/Args.java
+++ b/framework/src/main/java/org/tron/core/config/args/Args.java
@@ -563,6 +563,7 @@ public class Args extends CommonParameter {
 
     // ---- P2P sub-bean ----
     PARAMETER.nodeP2pVersion = nc.getP2p().getVersion();
+    PARAMETER.helloMsgTimestampThreshold = nc.getP2p().getHelloMsgTimestampThreshold();
 
     // ---- DNS sub-bean (tree URLs only — publish config uses complex validation) ----
     PARAMETER.dnsTreeUrls = nc.getDns().getTreeUrls().isEmpty()
@@ -1315,4 +1316,3 @@ public class Args extends CommonParameter {
     return optionGroupMap;
   }
 }
-

--- a/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
+++ b/framework/src/main/java/org/tron/core/net/service/relay/RelayService.java
@@ -1,5 +1,7 @@
 package org.tron.core.net.service.relay;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.protobuf.ByteString;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -73,6 +75,13 @@ public class RelayService {
           .copyFrom(Args.getLocalWitnesses().getWitnessAccountAddress()) : null;
 
   private int maxFastForwardNum = Args.getInstance().getMaxFastForwardNum();
+
+  private final long timestampThreshold =
+      Args.getInstance().getHelloMsgTimestampThreshold() * 1000L;
+
+  private final Cache<ByteString, Long> helloReplayCache = CacheBuilder.newBuilder()
+      .maximumSize(100)
+      .build();
 
   public void init() {
     manager = ctx.getBean(Manager.class);
@@ -156,6 +165,20 @@ public class RelayService {
       return false;
     }
 
+    long now = System.currentTimeMillis();
+    if (now - msg.getTimestamp() > timestampThreshold) {
+      logger.warn("HelloMessage from {}, timestamp {} is stale, threshold {} ms",
+          channel.getInetAddress(), msg.getTimestamp(), timestampThreshold);
+      return false;
+    }
+
+    Long lastTimestamp = helloReplayCache.getIfPresent(msg.getAddress());
+    if (lastTimestamp != null && msg.getTimestamp() <= lastTimestamp) {
+      logger.warn("HelloMessage from {}, timestamp {} is not greater than last {}",
+          channel.getInetAddress(), msg.getTimestamp(), lastTimestamp);
+      return false;
+    }
+
     boolean flag;
     try {
       Sha256Hash hash = Sha256Hash.of(CommonParameter
@@ -172,6 +195,7 @@ public class RelayService {
         flag = Arrays.equals(sigAddress, witnessPermissionAddress);
       }
       if (flag) {
+        helloReplayCache.put(msg.getAddress(), msg.getTimestamp());
         TronNetService.getP2pConfig().getTrustNodes().add(channel.getInetAddress());
         DesensitizedConverter.addSensitive(channel.getInetAddress().toString().substring(1),
             ByteArray.toHexString(msg.getAddress().toByteArray()));

--- a/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
+++ b/framework/src/test/java/org/tron/core/net/services/RelayServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
+import com.google.common.cache.Cache;
 import com.google.protobuf.ByteString;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -73,6 +74,11 @@ public class RelayServiceTest extends BaseTest {
   @After
   public void clearPeers() {
     closePeer();
+    Cache<?, ?> cache =
+        (Cache<?, ?>) ReflectUtils.getFieldObject(service, "helloReplayCache");
+    if (cache != null) {
+      cache.invalidateAll();
+    }
   }
 
   @Test
@@ -248,6 +254,102 @@ public class RelayServiceTest extends BaseTest {
       logger.info("", e);
       assert false;
     }
+  }
+
+  private HelloMessage buildSignedHello(long timestamp) throws Exception {
+    String key = "0154435f065a57fec6af1e12eaa2fa600030639448d7809f4c65bdcf8baed7e5";
+    ByteString address = getFromHexString("418A8D690BF36806C36A7DAE3AF796643C1AA9CC01");
+    Node node = new Node(NetUtil.getNodeId(), "127.0.0.1", null, 10001);
+    HelloMessage msg = new HelloMessage(node, timestamp,
+        ChainBaseManager.getChainBaseManager());
+    SignInterface engine = SignUtils.fromPrivate(ByteArray.fromHexString(key),
+        Args.getInstance().isECKeyCryptoEngine());
+    ByteString sig = ByteString.copyFrom(engine.Base64toBytes(engine
+        .signHash(Sha256Hash.of(CommonParameter.getInstance()
+            .isECKeyCryptoEngine(), ByteArray.fromLong(timestamp)).getBytes())));
+    msg.setHelloMessage(msg.getHelloMessage().toBuilder()
+        .setAddress(address)
+        .setSignature(sig)
+        .build());
+    return msg;
+  }
+
+  private Channel buildChannel() {
+    InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10001);
+    Channel c = mock(Channel.class);
+    Mockito.when(c.getInetSocketAddress()).thenReturn(addr);
+    Mockito.when(c.getInetAddress()).thenReturn(addr.getAddress());
+    return c;
+  }
+
+  private void setupRelayServiceDeps() throws Exception {
+    Field f1 = service.getClass().getDeclaredField("witnessScheduleStore");
+    f1.setAccessible(true);
+    f1.set(service, chainBaseManager.getWitnessScheduleStore());
+    Field f2 = service.getClass().getDeclaredField("manager");
+    f2.setAccessible(true);
+    f2.set(service, dbManager);
+    ReflectUtils.setFieldValue(tronNetService, "p2pConfig", new P2pConfig());
+  }
+
+  @Test
+  public void testCheckHelloMessage_staleTimestamp() throws Exception {
+    initWitness();
+    setupRelayServiceDeps();
+    Args.getInstance().fastForward = true;
+    long threshold = Args.getInstance().getHelloMsgTimestampThreshold() * 1000L;
+    long staleTimestamp = System.currentTimeMillis() - threshold - 1000;
+    HelloMessage msg = buildSignedHello(staleTimestamp);
+    boolean result = service.checkHelloMessage(msg, buildChannel());
+    Assert.assertFalse(result);
+  }
+
+  @Test
+  public void testCheckHelloMessage_freshTimestamp() throws Exception {
+    initWitness();
+    setupRelayServiceDeps();
+    Args.getInstance().fastForward = true;
+    long freshTimestamp = System.currentTimeMillis();
+    HelloMessage msg = buildSignedHello(freshTimestamp);
+    boolean result = service.checkHelloMessage(msg, buildChannel());
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void testCheckHelloMessage_replayRejected() throws Exception {
+    initWitness();
+    setupRelayServiceDeps();
+    Args.getInstance().fastForward = true;
+    long t = System.currentTimeMillis();
+    HelloMessage msg1 = buildSignedHello(t);
+    Assert.assertTrue(service.checkHelloMessage(msg1, buildChannel()));
+    HelloMessage msg2 = buildSignedHello(t);
+    Assert.assertFalse(service.checkHelloMessage(msg2, buildChannel()));
+  }
+
+  @Test
+  public void testCheckHelloMessage_strictlyLargerTimestampPasses() throws Exception {
+    initWitness();
+    setupRelayServiceDeps();
+    Args.getInstance().fastForward = true;
+    long t = System.currentTimeMillis();
+    Assert.assertTrue(service.checkHelloMessage(buildSignedHello(t), buildChannel()));
+    Assert.assertTrue(service.checkHelloMessage(buildSignedHello(t + 1), buildChannel()));
+  }
+
+  @Test
+  public void testCheckHelloMessage_badSigDoesNotPoisonCache() throws Exception {
+    initWitness();
+    setupRelayServiceDeps();
+    Args.getInstance().fastForward = true;
+    long t = System.currentTimeMillis();
+    HelloMessage badMsg = buildSignedHello(t);
+    badMsg.setHelloMessage(badMsg.getHelloMessage().toBuilder()
+        .setSignature(ByteString.copyFrom(new byte[65]))
+        .build());
+    Assert.assertFalse(service.checkHelloMessage(badMsg, buildChannel()));
+    HelloMessage goodMsg = buildSignedHello(t);
+    Assert.assertTrue(service.checkHelloMessage(goodMsg, buildChannel()));
   }
 
   @Test


### PR DESCRIPTION
Hello messages were accepted without checking timestamp freshness, allowing a previously signed witness message to be replayed indefinitely.

Add a configurable freshness threshold and track the latest verified timestamp per witness so stale or repeated messages are rejected before trust is granted. Adapt the setting to the current NodeConfig-based configuration model while retaining signature-length validation.

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

