### PR TITLE
fix(db): invalidate permission cache after reorg

### DIFF
--- a/framework/src/main/java/org/tron/core/db/Manager.java
+++ b/framework/src/main/java/org/tron/core/db/Manager.java
@@ -1040,8 +1040,12 @@ public class Manager {
       khaosDb.pop();
       revokingStore.fastPop();
       logger.info("End to erase block: {}.", oldHeadBlock);
-      oldHeadBlock.getTransactions().forEach(tc ->
-          poppedTransactions.add(new TransactionCapsule(tc.getInstance())));
+      oldHeadBlock.getTransactions().forEach(tc -> {
+        if (isMultiSignTransaction(tc.getInstance())) {
+          ownerAddressSet.add(ByteArray.toHexString(tc.getOwnerAddress()));
+        }
+        poppedTransactions.add(new TransactionCapsule(tc.getInstance()));
+      });
       Metrics.gaugeInc(MetricKeys.Gauge.MANAGER_QUEUE, oldHeadBlock.getTransactions().size(),
           MetricLabels.Gauge.QUEUE_POPPED);
 

--- a/framework/src/test/java/org/tron/core/db/ManagerTest.java
+++ b/framework/src/test/java/org/tron/core/db/ManagerTest.java
@@ -929,6 +929,39 @@ public class ManagerTest extends BaseMethodTest {
   }
 
   @Test
+  public void eraseBlockMarksPermissionUpdateOwnerForVerification() throws Exception {
+    byte[] owner = ByteArray.fromHexString(Wallet.getAddressPreFixString()
+        + "548794500882809695A8A687866E76D4271A1ABC");
+    AccountContract.AccountPermissionUpdateContract contract =
+        AccountContract.AccountPermissionUpdateContract.newBuilder()
+            .setOwnerAddress(ByteString.copyFrom(owner))
+            .build();
+    TransactionCapsule permissionUpdate = new TransactionCapsule(contract,
+        ContractType.AccountPermissionUpdateContract);
+    BlockCapsule rolledBackBlock = new BlockCapsule(1, Sha256Hash.ZERO_HASH.getByteString(), 0,
+        Arrays.asList(permissionUpdate.getInstance()));
+    rolledBackBlock.setMerkleRoot();
+
+    Manager manager = new Manager();
+    ChainBaseManager mockedChainManager = mock(ChainBaseManager.class);
+    DynamicPropertiesStore mockedDynamicPropertiesStore = mock(DynamicPropertiesStore.class);
+    when(mockedChainManager.getDynamicPropertiesStore()).thenReturn(mockedDynamicPropertiesStore);
+    when(mockedDynamicPropertiesStore.getLatestBlockHeaderHash())
+        .thenReturn(Sha256Hash.wrap(new byte[32]));
+    when(mockedChainManager.getBlockById(any(Sha256Hash.class))).thenReturn(rolledBackBlock);
+    ReflectUtils.setFieldValue(manager, "chainBaseManager", mockedChainManager);
+    ReflectUtils.setFieldValue(manager, "khaosDb", mock(KhaosDatabase.class));
+    ReflectUtils.setFieldValue(manager, "revokingStore", mock(RevokingDatabase.class));
+
+    manager.eraseBlock();
+
+    @SuppressWarnings("unchecked")
+    Set<String> ownerAddressSet =
+        (Set<String>) ReflectUtils.getFieldObject(manager, "ownerAddressSet");
+    Assert.assertTrue(ownerAddressSet.contains(ByteArray.toHexString(owner)));
+  }
+
+  @Test
   public void doNotSwitch()
       throws ValidateSignatureException, ContractValidateException, ContractExeException,
       UnLinkedBlockException, ValidateScheduleException, BadItemException,


### PR DESCRIPTION
Account permissions are canonical chain state, but rolled-back permission updates did not restore the owner marker used to invalidate cached transaction verification. Mark affected owners while erasing old-branch blocks so repushed and packed transactions are verified against the new canonical state.

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

